### PR TITLE
feat: implement APK signing with release key and auto-version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,38 @@ jobs:
       - name: Regenerate Flutter project scaffold
         run: bash scripts/setup_flutter_app.sh
 
+      - name: Sync version from pyproject.toml to pubspec.yaml
+        run: |
+          # Extract version from pyproject.toml
+          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          # Convert to Flutter version format: major.minor.patch+buildNumber
+          # For now, use patch as build number (e.g., 5.0.0 -> 5.0.0+500 where 500 is patch*100 + minor*10 + major)
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+          BUILD_NUMBER=$((MAJOR * 10000 + MINOR * 100 + PATCH))
+
+          # Update pubspec.yaml version
+          sed -i "s/^version: .*/version: $VERSION+$BUILD_NUMBER/" android_app/pubspec.yaml
+          echo "Updated pubspec.yaml to version: $VERSION+$BUILD_NUMBER"
+          cat android_app/pubspec.yaml | grep version
+
+      - name: Set up Android signing
+        env:
+          ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_FILE" ]; then
+            echo "Warning: Android keystore secrets not configured. Using debug signing."
+            exit 0
+          fi
+          # Decode base64 keystore file
+          echo "$ANDROID_KEYSTORE_FILE" | base64 -d > "$HOME/release.jks"
+          echo "KEYSTORE_PATH=$HOME/release.jks" >> $GITHUB_ENV
+          echo "Keystore file created at $HOME/release.jks"
+
       - name: Install Flutter dependencies
         working-directory: android_app
         run: flutter pub get
@@ -169,6 +201,11 @@ jobs:
 
       - name: Build release APK
         working-directory: android_app
+        env:
+          KEYSTORE_PATH: ${{ env.KEYSTORE_PATH }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: flutter build apk --release
 
       - name: Upload APK artifact

--- a/android_app/android/app/build.gradle.kts
+++ b/android_app/android/app/build.gradle.kts
@@ -30,11 +30,26 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            val keystorePath = System.getenv("KEYSTORE_PATH")
+            val keystorePassword = System.getenv("KEYSTORE_PASSWORD")
+            val keyAlias = System.getenv("KEY_ALIAS")
+            val keyPassword = System.getenv("KEY_PASSWORD")
+
+            if (!keystorePath.isNullOrEmpty() && !keystorePassword.isNullOrEmpty() &&
+                !keyAlias.isNullOrEmpty() && !keyPassword.isNullOrEmpty()) {
+                storeFile = file(keystorePath)
+                storePassword = keystorePassword
+                keyAlias = keyAlias
+                keyPassword = keyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }


### PR DESCRIPTION
- Add release signing configuration in build.gradle.kts
  - Reads keystore credentials from environment variables
  - Uses consistent release key instead of debug key for APK signing
  - Allows users to upgrade APK without uninstalling previous version

- Update release workflow to sync versions and configure signing
  - Extract version from pyproject.toml
  - Auto-sync to pubspec.yaml in Flutter format (e.g., 5.0.0+50000)
  - Decode base64 keystore file from GitHub secrets
  - Pass signing credentials to gradle build

- Keystore credentials stored in GitHub secrets (not in repo):
  - ANDROID_KEYSTORE_FILE (base64 encoded)
  - KEYSTORE_PASSWORD
  - KEY_ALIAS (lingodiary_release)
  - KEY_PASSWORD

User must:
1. Generate keystore locally with keytool
2. Base64 encode and add to GitHub secrets
3. Trigger release workflow to test

Fixes: Users had to uninstall old APK before installing new version
Fixes: Version mismatch between pyproject.toml and pubspec.yaml

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
