### PR TITLE
FIxTiming

### DIFF
--- a/android_app/lib/l10n/app_localizations.dart
+++ b/android_app/lib/l10n/app_localizations.dart
@@ -79,6 +79,147 @@ class AppLocalizations {
   String get helpBody => _t('helpBody');
   String get helpClose => _t('helpClose');
 
+  // Shared UI
+  String get retryButton => _t('retryButton');
+  String get refreshButton => _t('refreshButton');
+  String get addButton => _t('addButton');
+  String get changeButton => _t('changeButton');
+  String get editTooltip => _t('editTooltip');
+  String get removeTooltip => _t('removeTooltip');
+  String get confirmTooltip => _t('confirmTooltip');
+  String get stopButton => _t('stopButton');
+  String get playAllButton => _t('playAllButton');
+  String get skipButton => _t('skipButton');
+  String get refreshTooltip => _t('refreshTooltip');
+  String get helpTooltip => _t('helpTooltip');
+  String get settingsTooltip => _t('settingsTooltip');
+
+  // Nav
+  String get navHome => _t('navHome');
+  String get navReview => _t('navReview');
+  String get navReviewLessons => _t('navReviewLessons');
+  String get translationExercise => _t('translationExercise');
+
+  // Connection
+  String get serverOnline => _t('serverOnline');
+  String get serverOffline => _t('serverOffline');
+  String get serverUnreachableNoCache => _t('serverUnreachableNoCache');
+
+  // Diary
+  String get diaryDate => _t('diaryDate');
+  String diarySentencesFor(String date) => _t('diarySentencesFor').replaceAll('{date}', date);
+  String get diaryTypeSentenceHint => _t('diaryTypeSentenceHint');
+  String get diaryNoSentences => _t('diaryNoSentences');
+  String get diarySaveToServer => _t('diarySaveToServer');
+  String get diaryGenerateLessons => _t('diaryGenerateLessons');
+  String get diaryGenerationStarting => _t('diaryGenerationStarting');
+  String get diaryAddSentenceFirst => _t('diaryAddSentenceFirst');
+  String diaryEntrySaved(String date, int count) => _t('diaryEntrySaved').replaceAll('{date}', date).replaceAll('{count}', '$count');
+  String diarySavedLocally(String error) => _t('diarySavedLocally').replaceAll('{error}', error);
+  String get diaryCouldNotConnect => _t('diaryCouldNotConnect');
+
+  // Login
+  String loginConnectionError(String error) => _t('loginConnectionError').replaceAll('{error}', error);
+
+  // Home
+  String get homeProgress => _t('homeProgress');
+  String get homeMastered => _t('homeMastered');
+  String get homeInProgress => _t('homeInProgress');
+  String homeNewTotalEntries(int newCount, int total) => _t('homeNewTotalEntries').replaceAll('{newCount}', '$newCount').replaceAll('{total}', '$total');
+  String get homeStudyNow => _t('homeStudyNow');
+  String get reviewOptionsTooltip => _t('reviewOptionsTooltip');
+  String get originalReview => _t('originalReview');
+  String get dueForReview => _t('dueForReview');
+  String get newLesson => _t('newLesson');
+  String get homeRecentlyStudied => _t('homeRecentlyStudied');
+  String get homeNoLessonsStudied => _t('homeNoLessonsStudied');
+  String get timeAgoJustNow => _t('timeAgoJustNow');
+  String timeAgoDays(int count) => _t('timeAgoDays').replaceAll('{count}', '$count');
+  String timeAgoHours(int count) => _t('timeAgoHours').replaceAll('{count}', '$count');
+  String timeAgoMinutes(int count) => _t('timeAgoMinutes').replaceAll('{count}', '$count');
+
+  // Lessons
+  String lessonsMasteredCount(int mastered, int total) => _t('lessonsMasteredCount').replaceAll('{mastered}', '$mastered').replaceAll('{total}', '$total');
+
+  // Review (sentences_screen / native_first_sentences_screen)
+  String get sentenceReviewTitle => _t('sentenceReviewTitle');
+  String get translationExerciseTitle => _t('translationExerciseTitle');
+  String get syncAudioTooltip => _t('syncAudioTooltip');
+  String get syncCurrentSentence => _t('syncCurrentSentence');
+  String syncAllSentencesCount(int count) => _t('syncAllSentencesCount').replaceAll('{count}', '$count');
+  String get statsAndStreakTooltip => _t('statsAndStreakTooltip');
+  String reviewRemaining(int count) => _t('reviewRemaining').replaceAll('{count}', '$count');
+  String get offlineShowingCached => _t('offlineShowingCached');
+  String get offlineLoadNewSentences => _t('offlineLoadNewSentences');
+  String get downloadingAudio => _t('downloadingAudio');
+  String get audioUnavailable => _t('audioUnavailable');
+  String get audioSynced => _t('audioSynced');
+  String syncedAudioCount(int count) => _t('syncedAudioCount').replaceAll('{count}', '$count');
+  String get allCaughtUp => _t('allCaughtUp');
+  String get noSentencesDue => _t('noSentencesDue');
+  String get showTranslation => _t('showTranslation');
+  String get hideTranslation => _t('hideTranslation');
+  String showQa(int count) => _t('showQa').replaceAll('{count}', '$count');
+  String get hideQa => _t('hideQa');
+  String get howWellDidYouRemember => _t('howWellDidYouRemember');
+  String get scoreAgain => _t('scoreAgain');
+  String get scoreHard => _t('scoreHard');
+  String get scoreGood => _t('scoreGood');
+  String get scoreEasy => _t('scoreEasy');
+  String get scoreSavedWillSync => _t('scoreSavedWillSync');
+  String scoreSavedLocallyError(String error) => _t('scoreSavedLocallyError').replaceAll('{error}', error);
+  String get translationAttemptHintWithEnter => _t('translationAttemptHintWithEnter');
+  String get translationAttemptLabel => _t('translationAttemptLabel');
+  String get fontSizeSmall => _t('fontSizeSmall');
+  String get fontSizeNormal => _t('fontSizeNormal');
+  String get fontSizeLarge => _t('fontSizeLarge');
+  String get fontSizeExtraLarge => _t('fontSizeExtraLarge');
+
+  // Player
+  String get cycleVariantsOn => _t('cycleVariantsOn');
+  String get cycleVariantsOff => _t('cycleVariantsOff');
+  String get previousBlock => _t('previousBlock');
+  String get nextBlock => _t('nextBlock');
+  String get repeatCurrentBlock => _t('repeatCurrentBlock');
+  String get stopBlockRepeat => _t('stopBlockRepeat');
+  String get audioNotDownloadedYet => _t('audioNotDownloadedYet');
+  String get audioNotDownloaded => _t('audioNotDownloaded');
+  String get downloadingAudioWait => _t('downloadingAudioWait');
+  String get contentNotAvailable => _t('contentNotAvailable');
+  String get noDiaryEntriesFound => _t('noDiaryEntriesFound');
+  String couldNotLoadDiaryEntry(String error) => _t('couldNotLoadDiaryEntry').replaceAll('{error}', error);
+  String markedScore(String score) => _t('markedScore').replaceAll('{score}', score);
+  String markedScoreWithInterval(String score, int days) => _t('markedScoreWithInterval').replaceAll('{score}', score).replaceAll('{days}', '$days');
+
+  // Settings (new)
+  String get settingsLessonPlayback => _t('settingsLessonPlayback');
+  String get settingsAutoRepeatLesson => _t('settingsAutoRepeatLesson');
+  String get settingsAutoRepeatLessonSubtitle => _t('settingsAutoRepeatLessonSubtitle');
+  String get settingsAutoCycleVariants => _t('settingsAutoCycleVariants');
+  String get settingsAutoCycleVariantsSubtitle => _t('settingsAutoCycleVariantsSubtitle');
+  String get settingsMaintenance => _t('settingsMaintenance');
+  String get settingsFixEverything => _t('settingsFixEverything');
+  String get settingsFixEverythingSubtitle => _t('settingsFixEverythingSubtitle');
+  String get settingsFillQaTranslations => _t('settingsFillQaTranslations');
+  String get settingsFillQaTranslationsSubtitle => _t('settingsFillQaTranslationsSubtitle');
+  String get settingsRebuildAudioTiming => _t('settingsRebuildAudioTiming');
+  String get settingsRebuildAudioTimingSubtitle => _t('settingsRebuildAudioTimingSubtitle');
+  String get settingsForceAudioRegen => _t('settingsForceAudioRegen');
+  String get settingsForceAudioRegenSubtitle => _t('settingsForceAudioRegenSubtitle');
+  String get settingsJobStarted => _t('settingsJobStarted');
+  String settingsJobError(String error) => _t('settingsJobError').replaceAll('{error}', error);
+
+  // Stats
+  String get statsTitle => _t('statsTitle');
+  String get dayStreak => _t('dayStreak');
+  String reviewedToday(int count) => _t('reviewedToday').replaceAll('{count}', '$count');
+  String get noReviewsToday => _t('noReviewsToday');
+  String get statsOverview => _t('statsOverview');
+  String get statsTotalReviews => _t('statsTotalReviews');
+  String get statsReviewedTodayLabel => _t('statsReviewedTodayLabel');
+  String get statsNoScores => _t('statsNoScores');
+  String get statsScoreDistribution => _t('statsScoreDistribution');
+
   static const Map<String, Map<String, String>> _strings = {
     'en': {
       'appTitle': 'LingoDiary',
@@ -140,6 +281,126 @@ class AppLocalizations {
       'helpTitle': 'How it works',
       'helpBody': '1. Go to Diary and write a few sentences about your day in your native language.\n\n2. Tap Generate Lessons. The server translates each sentence and records audio with Q\u0026A.\n\n3. Open Lessons and listen. Each sentence is highlighted as it plays. Tap any sentence to reveal the translation.\n\n4. Score yourself at the end of each lesson to track your mastery over time.',
       'helpClose': 'Got it',
+      'retryButton': 'Retry',
+      'refreshButton': 'Refresh',
+      'addButton': 'Add',
+      'changeButton': 'Change',
+      'editTooltip': 'Edit',
+      'removeTooltip': 'Remove',
+      'confirmTooltip': 'Confirm',
+      'stopButton': 'Stop',
+      'playAllButton': 'Play all',
+      'skipButton': 'Skip',
+      'refreshTooltip': 'Refresh',
+      'helpTooltip': 'Help',
+      'settingsTooltip': 'Settings',
+      'navHome': 'Home',
+      'navReview': 'Review',
+      'navReviewLessons': 'Review Lessons',
+      'translationExercise': 'Translation Exercise',
+      'serverOnline': 'Server online',
+      'serverOffline': 'Server offline',
+      'serverUnreachableNoCache': 'Server unreachable — no cached data.',
+      'diaryDate': 'Diary date',
+      'diarySentencesFor': 'Sentences for {date}',
+      'diaryTypeSentenceHint': 'Type a sentence…',
+      'diaryNoSentences': 'No sentences yet.',
+      'diarySaveToServer': 'Save to Server',
+      'diaryGenerateLessons': 'Generate Lessons',
+      'diaryGenerationStarting': 'Starting generation…',
+      'diaryAddSentenceFirst': 'Add at least one sentence first.',
+      'diaryEntrySaved': '✓ Entry saved for {date} ({count} sentence(s))',
+      'diarySavedLocally': 'Saved locally. Will sync on next connection.\n{error}',
+      'diaryCouldNotConnect': 'Could not connect to server.',
+      'loginConnectionError': 'Error: {error}\n\nCheck the server URL is correct and the server is reachable.',
+      'homeProgress': 'Progress',
+      'homeMastered': 'Mastered',
+      'homeInProgress': 'In progress',
+      'homeNewTotalEntries': '{newCount} new • {total} total entries',
+      'homeStudyNow': 'Study Now',
+      'reviewOptionsTooltip': 'Review options',
+      'originalReview': 'Original Review',
+      'dueForReview': 'Due for review',
+      'newLesson': 'New lesson',
+      'homeRecentlyStudied': 'Recently Studied',
+      'homeNoLessonsStudied': 'No lessons studied yet.',
+      'timeAgoJustNow': 'Just now',
+      'timeAgoDays': '{count}d ago',
+      'timeAgoHours': '{count}h ago',
+      'timeAgoMinutes': '{count}m ago',
+      'lessonsMasteredCount': '{mastered}/{total} mastered',
+      'sentenceReviewTitle': 'Sentence Review',
+      'translationExerciseTitle': 'Translation Exercise',
+      'syncAudioTooltip': 'Sync audio',
+      'syncCurrentSentence': 'Sync current sentence',
+      'syncAllSentencesCount': 'Sync all ({count} sentences)',
+      'statsAndStreakTooltip': 'Stats & Streak',
+      'reviewRemaining': '{count} left',
+      'offlineShowingCached': 'Offline — showing cached review. Scores will sync when connected.',
+      'offlineLoadNewSentences': 'Offline — sync the app when connected to load new sentences.',
+      'downloadingAudio': 'Downloading audio…',
+      'audioUnavailable': 'Audio unavailable',
+      'audioSynced': 'Audio synced',
+      'syncedAudioCount': 'Synced audio for {count} sentences',
+      'allCaughtUp': 'All caught up!',
+      'noSentencesDue': 'No sentences due for review right now.',
+      'showTranslation': 'Show translation',
+      'hideTranslation': 'Hide translation',
+      'showQa': 'Show Q&A ({count} pairs)',
+      'hideQa': 'Hide Q&A',
+      'howWellDidYouRemember': 'How well did you remember?',
+      'scoreAgain': 'Again',
+      'scoreHard': 'Hard',
+      'scoreGood': 'Good',
+      'scoreEasy': 'Easy',
+      'scoreSavedWillSync': 'Score saved (will sync when online)',
+      'scoreSavedLocallyError': 'Score saved locally — sync error: {error}',
+      'translationAttemptHintWithEnter': 'Your translation attempt (press Enter to reveal)',
+      'translationAttemptLabel': 'Your translation attempt',
+      'fontSizeSmall': 'Small',
+      'fontSizeNormal': 'Normal',
+      'fontSizeLarge': 'Large',
+      'fontSizeExtraLarge': 'Extra Large',
+      'cycleVariantsOn': 'Cycle variants: on',
+      'cycleVariantsOff': 'Cycle variants: off',
+      'previousBlock': 'Previous block',
+      'nextBlock': 'Next block',
+      'repeatCurrentBlock': 'Repeat current block',
+      'stopBlockRepeat': 'Stop block repeat',
+      'audioNotDownloadedYet': '⏳ Audio not downloaded yet — syncing now, please wait…',
+      'audioNotDownloaded': 'Audio not downloaded — tap ▶ or sync ⟳ to download',
+      'downloadingAudioWait': 'Downloading audio… please wait',
+      'contentNotAvailable': 'Content not available.\nSync the lesson to view it offline.',
+      'noDiaryEntriesFound': '(No diary entries found)',
+      'couldNotLoadDiaryEntry': 'Could not load diary entry.\nTap sync or check server connection.\n\nError: {error}',
+      'markedScore': 'Marked {score}',
+      'markedScoreWithInterval': 'Marked {score} — next in {days} days',
+      'settingsLessonPlayback': 'Lesson playback',
+      'settingsAutoRepeatLesson': 'Auto-repeat lesson',
+      'settingsAutoRepeatLessonSubtitle': 'Start each lesson with the repeat loop enabled by default',
+      'settingsAutoCycleVariants': 'Auto-cycle all variants',
+      'settingsAutoCycleVariantsSubtitle': 'When a variant finishes, automatically play the next one: Original → Enhanced → Present → Future, then stop',
+      'settingsMaintenance': 'Maintenance',
+      'settingsFixEverything': 'Fix everything',
+      'settingsFixEverythingSubtitle': 'Sync diary, fill missing Q&A and rebuild audio timing in one go',
+      'settingsFillQaTranslations': 'Fill missing Q&A translations',
+      'settingsFillQaTranslationsSubtitle': 'Generates Q&A pairs not yet translated into your study language',
+      'settingsRebuildAudioTiming': 'Rebuild audio timing',
+      'settingsRebuildAudioTimingSubtitle': 'Recomputes sentence-highlight sync for all lessons',
+      'settingsForceAudioRegen': 'Force audio re-generation',
+      'settingsForceAudioRegenSubtitle': 'Re-runs TTS for every lesson (slow). Leave off to only recompute timing from existing files.',
+      'settingsJobStarted': 'Started — this may take several minutes',
+      'settingsJobError': 'Error: {error}',
+      'statsTitle': 'Stats & Streak',
+      'refreshTooltipStats': 'Refresh',
+      'dayStreak': 'day streak',
+      'reviewedToday': '✓ {count} reviewed today',
+      'noReviewsToday': 'No reviews yet today',
+      'statsOverview': 'Overview',
+      'statsTotalReviews': 'Total reviews',
+      'statsReviewedTodayLabel': 'Reviewed today',
+      'statsNoScores': 'No scores recorded yet.',
+      'statsScoreDistribution': 'Score distribution',
     },
     'fr': {
       'appTitle': 'LingoDiary',
@@ -201,6 +462,125 @@ class AppLocalizations {
       'helpTitle': 'Comment \u00e7a marche',
       'helpBody': '1. Allez dans Journal et \u00e9crivez quelques phrases sur votre journ\u00e9e dans votre langue maternelle.\n\n2. Appuyez sur G\u00e9n\u00e9rer des le\u00e7ons. Le serveur traduit chaque phrase et enregistre l\u2019audio avec des questions-r\u00e9ponses.\n\n3. Ouvrez Le\u00e7ons et \u00e9coutez. Chaque phrase est mise en \u00e9vidence pendant la lecture. Appuyez sur une phrase pour r\u00e9v\u00e9ler la traduction.\n\n4. Notez-vous \u00e0 la fin de chaque le\u00e7on pour suivre votre progression.',
       'helpClose': 'Compris',
+      'retryButton': 'Réessayer',
+      'refreshButton': 'Actualiser',
+      'addButton': 'Ajouter',
+      'changeButton': 'Modifier',
+      'editTooltip': 'Modifier',
+      'removeTooltip': 'Supprimer',
+      'confirmTooltip': 'Confirmer',
+      'stopButton': 'Arrêter',
+      'playAllButton': 'Tout lire',
+      'skipButton': 'Passer',
+      'refreshTooltip': 'Actualiser',
+      'helpTooltip': 'Aide',
+      'settingsTooltip': 'Paramètres',
+      'navHome': 'Accueil',
+      'navReview': 'Révision',
+      'navReviewLessons': 'Réviser les leçons',
+      'translationExercise': 'Exercice de traduction',
+      'serverOnline': 'Serveur en ligne',
+      'serverOffline': 'Serveur hors ligne',
+      'serverUnreachableNoCache': 'Serveur inaccessible — aucune donnée en cache.',
+      'diaryDate': 'Date du journal',
+      'diarySentencesFor': 'Phrases pour {date}',
+      'diaryTypeSentenceHint': 'Écrivez une phrase…',
+      'diaryNoSentences': 'Aucune phrase pour l’instant.',
+      'diarySaveToServer': 'Enregistrer sur le serveur',
+      'diaryGenerateLessons': 'Générer les leçons',
+      'diaryGenerationStarting': 'Démarrage de la génération…',
+      'diaryAddSentenceFirst': 'Ajoutez au moins une phrase d’abord.',
+      'diaryEntrySaved': '✓ Entrée enregistrée pour {date} ({count} phrase(s))',
+      'diarySavedLocally': 'Enregistré localement. Sera synchronisé à la prochaine connexion.\n{error}',
+      'diaryCouldNotConnect': 'Impossible de se connecter au serveur.',
+      'loginConnectionError': 'Erreur : {error}\n\nVérifiez que l’URL du serveur est correcte et que le serveur est accessible.',
+      'homeProgress': 'Progression',
+      'homeMastered': 'Maîtrisé',
+      'homeInProgress': 'En cours',
+      'homeNewTotalEntries': '{newCount} nouveau(x) • {total} entrée(s) au total',
+      'homeStudyNow': 'Étudier maintenant',
+      'reviewOptionsTooltip': 'Options de révision',
+      'originalReview': 'Révision originale',
+      'dueForReview': 'À réviser',
+      'newLesson': 'Nouvelle leçon',
+      'homeRecentlyStudied': 'Récemment étudié',
+      'homeNoLessonsStudied': 'Aucune leçon étudiée pour l’instant.',
+      'timeAgoJustNow': 'À l’instant',
+      'timeAgoDays': 'il y a {count} j',
+      'timeAgoHours': 'il y a {count} h',
+      'timeAgoMinutes': 'il y a {count} min',
+      'lessonsMasteredCount': '{mastered}/{total} maîtrisé(s)',
+      'sentenceReviewTitle': 'Révision de phrases',
+      'translationExerciseTitle': 'Exercice de traduction',
+      'syncAudioTooltip': 'Synchroniser l’audio',
+      'syncCurrentSentence': 'Synchroniser la phrase actuelle',
+      'syncAllSentencesCount': 'Synchroniser tout ({count} phrases)',
+      'statsAndStreakTooltip': 'Stats & Série',
+      'reviewRemaining': '{count} restant(s)',
+      'offlineShowingCached': 'Hors ligne — révision en cache. Les scores seront synchronisés quand connecté.',
+      'offlineLoadNewSentences': 'Hors ligne — synchronisez l’app quand connecté pour charger de nouvelles phrases.',
+      'downloadingAudio': 'Téléchargement de l’audio…',
+      'audioUnavailable': 'Audio non disponible',
+      'audioSynced': 'Audio synchronisé',
+      'syncedAudioCount': 'Audio synchronisé pour {count} phrase(s)',
+      'allCaughtUp': 'Tout à jour !',
+      'noSentencesDue': 'Aucune phrase à réviser pour l’instant.',
+      'showTranslation': 'Afficher la traduction',
+      'hideTranslation': 'Masquer la traduction',
+      'showQa': 'Afficher Q&R ({count} paires)',
+      'hideQa': 'Masquer Q&R',
+      'howWellDidYouRemember': 'Dans quelle mesure vous en souvenez-vous ?',
+      'scoreAgain': 'Encore',
+      'scoreHard': 'Difficile',
+      'scoreGood': 'Bien',
+      'scoreEasy': 'Facile',
+      'scoreSavedWillSync': 'Score enregistré (sera synchronisé quand connecté)',
+      'scoreSavedLocallyError': 'Score enregistré localement — erreur de sync : {error}',
+      'translationAttemptHintWithEnter': 'Votre tentative de traduction (appuyez sur Entrée pour révéler)',
+      'translationAttemptLabel': 'Votre tentative de traduction',
+      'fontSizeSmall': 'Petit',
+      'fontSizeNormal': 'Normal',
+      'fontSizeLarge': 'Grand',
+      'fontSizeExtraLarge': 'Très grand',
+      'cycleVariantsOn': 'Cycle de variantes : activé',
+      'cycleVariantsOff': 'Cycle de variantes : désactivé',
+      'previousBlock': 'Bloc précédent',
+      'nextBlock': 'Bloc suivant',
+      'repeatCurrentBlock': 'Répéter le bloc actuel',
+      'stopBlockRepeat': 'Arrêter la répétition du bloc',
+      'audioNotDownloadedYet': '⏳ Audio non téléchargé — synchronisation en cours, veuillez patienter…',
+      'audioNotDownloaded': 'Audio non téléchargé — appuyez sur ▶ ou synchronisez ⟳ pour télécharger',
+      'downloadingAudioWait': 'Téléchargement de l’audio… veuillez patienter',
+      'contentNotAvailable': 'Contenu non disponible.\nSynchronisez la leçon pour la consulter hors ligne.',
+      'noDiaryEntriesFound': '(Aucune entrée de journal trouvée)',
+      'couldNotLoadDiaryEntry': 'Impossible de charger l’entrée du journal.\nAppuyez sur sync ou vérifiez la connexion au serveur.\n\nErreur : {error}',
+      'markedScore': 'Noté {score}',
+      'markedScoreWithInterval': 'Noté {score} — suivant dans {days} jours',
+      'settingsLessonPlayback': 'Lecture des leçons',
+      'settingsAutoRepeatLesson': 'Répétition automatique',
+      'settingsAutoRepeatLessonSubtitle': 'Commencer chaque leçon avec la boucle de répétition activée par défaut',
+      'settingsAutoCycleVariants': 'Cycle automatique des variantes',
+      'settingsAutoCycleVariantsSubtitle': 'Quand une variante se termine, passer automatiquement à la suivante : Original → Amélioré → Présent → Futur, puis s’arrêter',
+      'settingsMaintenance': 'Maintenance',
+      'settingsFixEverything': 'Tout corriger',
+      'settingsFixEverythingSubtitle': 'Synchroniser le journal, remplir les Q&R manquants et reconstruire le timing audio en une fois',
+      'settingsFillQaTranslations': 'Remplir les traductions Q&R manquantes',
+      'settingsFillQaTranslationsSubtitle': 'Génère les paires Q&R non encore traduites dans votre langue d’étude',
+      'settingsRebuildAudioTiming': 'Reconstruire le timing audio',
+      'settingsRebuildAudioTimingSubtitle': 'Recalcule la synchronisation des sous-titres pour toutes les leçons',
+      'settingsForceAudioRegen': 'Forcer la re-génération audio',
+      'settingsForceAudioRegenSubtitle': 'Relance la TTS pour chaque leçon (lent). Désactivez pour ne recalculer que le timing depuis les fichiers existants.',
+      'settingsJobStarted': 'Démarré — cela peut prendre plusieurs minutes',
+      'settingsJobError': 'Erreur : {error}',
+      'statsTitle': 'Stats & Série',
+      'dayStreak': 'jour(s) de série',
+      'reviewedToday': '✓ {count} révisé(s) aujourd’hui',
+      'noReviewsToday': 'Aucune révision aujourd’hui',
+      'statsOverview': 'Aperçu',
+      'statsTotalReviews': 'Total des révisions',
+      'statsReviewedTodayLabel': 'Révisé aujourd’hui',
+      'statsNoScores': 'Aucun score enregistré pour l’instant.',
+      'statsScoreDistribution': 'Distribution des scores',
     },
     'es': {
       'appTitle': 'LingoDiary',
@@ -262,6 +642,125 @@ class AppLocalizations {
       'helpTitle': 'C\u00f3mo funciona',
       'helpBody': '1. Ve a Diario y escribe algunas frases sobre tu d\u00eda en tu idioma nativo.\n\n2. Pulsa Generar lecciones. El servidor traduce cada frase y graba el audio con preguntas y respuestas.\n\n3. Abre Lecciones y escucha. Cada frase se resalta mientras se reproduce. Pulsa una frase para ver la traducci\u00f3n.\n\n4. Punt\u00faate al final de cada lecci\u00f3n para seguir tu progreso.',
       'helpClose': 'Entendido',
+      'retryButton': 'Reintentar',
+      'refreshButton': 'Actualizar',
+      'addButton': 'Añadir',
+      'changeButton': 'Cambiar',
+      'editTooltip': 'Editar',
+      'removeTooltip': 'Eliminar',
+      'confirmTooltip': 'Confirmar',
+      'stopButton': 'Detener',
+      'playAllButton': 'Reproducir todo',
+      'skipButton': 'Omitir',
+      'refreshTooltip': 'Actualizar',
+      'helpTooltip': 'Ayuda',
+      'settingsTooltip': 'Ajustes',
+      'navHome': 'Inicio',
+      'navReview': 'Revisión',
+      'navReviewLessons': 'Revisar lecciones',
+      'translationExercise': 'Ejercicio de traducción',
+      'serverOnline': 'Servidor en línea',
+      'serverOffline': 'Servidor sin conexión',
+      'serverUnreachableNoCache': 'Servidor no disponible — sin datos en caché.',
+      'diaryDate': 'Fecha del diario',
+      'diarySentencesFor': 'Frases para {date}',
+      'diaryTypeSentenceHint': 'Escribe una frase…',
+      'diaryNoSentences': 'Aún no hay frases.',
+      'diarySaveToServer': 'Guardar en el servidor',
+      'diaryGenerateLessons': 'Generar lecciones',
+      'diaryGenerationStarting': 'Iniciando generación…',
+      'diaryAddSentenceFirst': 'Añade al menos una frase primero.',
+      'diaryEntrySaved': '✓ Entrada guardada para {date} ({count} frase(s))',
+      'diarySavedLocally': 'Guardado localmente. Se sincronizará en la próxima conexión.\n{error}',
+      'diaryCouldNotConnect': 'No se pudo conectar al servidor.',
+      'loginConnectionError': 'Error: {error}\n\nVerifica que la URL del servidor sea correcta y que el servidor sea accesible.',
+      'homeProgress': 'Progreso',
+      'homeMastered': 'Dominado',
+      'homeInProgress': 'En progreso',
+      'homeNewTotalEntries': '{newCount} nuevo(s) • {total} entrada(s) en total',
+      'homeStudyNow': 'Estudiar ahora',
+      'reviewOptionsTooltip': 'Opciones de revisión',
+      'originalReview': 'Revisión original',
+      'dueForReview': 'Para revisar',
+      'newLesson': 'Nueva lección',
+      'homeRecentlyStudied': 'Estudiado recientemente',
+      'homeNoLessonsStudied': 'Aún no se ha estudiado ninguna lección.',
+      'timeAgoJustNow': 'Ahora mismo',
+      'timeAgoDays': 'hace {count}d',
+      'timeAgoHours': 'hace {count}h',
+      'timeAgoMinutes': 'hace {count}min',
+      'lessonsMasteredCount': '{mastered}/{total} dominado(s)',
+      'sentenceReviewTitle': 'Revisión de frases',
+      'translationExerciseTitle': 'Ejercicio de traducción',
+      'syncAudioTooltip': 'Sincronizar audio',
+      'syncCurrentSentence': 'Sincronizar frase actual',
+      'syncAllSentencesCount': 'Sincronizar todo ({count} frases)',
+      'statsAndStreakTooltip': 'Estadísticas y racha',
+      'reviewRemaining': '{count} restante(s)',
+      'offlineShowingCached': 'Sin conexión — mostrando revisión en caché. Las puntuaciones se sincronizarán al conectarse.',
+      'offlineLoadNewSentences': 'Sin conexión — sincroniza la app al conectarte para cargar nuevas frases.',
+      'downloadingAudio': 'Descargando audio…',
+      'audioUnavailable': 'Audio no disponible',
+      'audioSynced': 'Audio sincronizado',
+      'syncedAudioCount': 'Audio sincronizado para {count} frase(s)',
+      'allCaughtUp': '¡Todo al día!',
+      'noSentencesDue': 'No hay frases pendientes de revisión ahora mismo.',
+      'showTranslation': 'Mostrar traducción',
+      'hideTranslation': 'Ocultar traducción',
+      'showQa': 'Mostrar P&R ({count} pares)',
+      'hideQa': 'Ocultar P&R',
+      'howWellDidYouRemember': '¿Qué tan bien lo recordaste?',
+      'scoreAgain': 'Otra vez',
+      'scoreHard': 'Difícil',
+      'scoreGood': 'Bien',
+      'scoreEasy': 'Fácil',
+      'scoreSavedWillSync': 'Puntuación guardada (se sincronizará al conectarse)',
+      'scoreSavedLocallyError': 'Puntuación guardada localmente — error de sincronización: {error}',
+      'translationAttemptHintWithEnter': 'Tu intento de traducción (presiona Enter para revelar)',
+      'translationAttemptLabel': 'Tu intento de traducción',
+      'fontSizeSmall': 'Pequeño',
+      'fontSizeNormal': 'Normal',
+      'fontSizeLarge': 'Grande',
+      'fontSizeExtraLarge': 'Extra grande',
+      'cycleVariantsOn': 'Ciclo de variantes: activado',
+      'cycleVariantsOff': 'Ciclo de variantes: desactivado',
+      'previousBlock': 'Bloque anterior',
+      'nextBlock': 'Siguiente bloque',
+      'repeatCurrentBlock': 'Repetir bloque actual',
+      'stopBlockRepeat': 'Detener repetición de bloque',
+      'audioNotDownloadedYet': '⏳ Audio no descargado — sincronizando, espera…',
+      'audioNotDownloaded': 'Audio no descargado — pulsa ▶ o sincroniza ⟳ para descargar',
+      'downloadingAudioWait': 'Descargando audio… por favor espera',
+      'contentNotAvailable': 'Contenido no disponible.\nSincroniza la lección para verla sin conexión.',
+      'noDiaryEntriesFound': '(No se encontraron entradas de diario)',
+      'couldNotLoadDiaryEntry': 'No se pudo cargar la entrada del diario.\nToca sincronizar o verifica la conexión al servidor.\n\nError: {error}',
+      'markedScore': 'Marcado {score}',
+      'markedScoreWithInterval': 'Marcado {score} — próximo en {days} días',
+      'settingsLessonPlayback': 'Reproducción de lecciones',
+      'settingsAutoRepeatLesson': 'Repetición automática',
+      'settingsAutoRepeatLessonSubtitle': 'Iniciar cada lección con el bucle de repetición activado por defecto',
+      'settingsAutoCycleVariants': 'Ciclo automático de variantes',
+      'settingsAutoCycleVariantsSubtitle': 'Cuando termina una variante, reproducir automáticamente la siguiente: Original → Mejorada → Presente → Futuro, luego parar',
+      'settingsMaintenance': 'Mantenimiento',
+      'settingsFixEverything': 'Arreglar todo',
+      'settingsFixEverythingSubtitle': 'Sincronizar diario, completar P&R faltantes y reconstruir el timing de audio en un solo paso',
+      'settingsFillQaTranslations': 'Completar traducciones P&R faltantes',
+      'settingsFillQaTranslationsSubtitle': 'Genera pares P&R no traducidos aún a tu idioma de estudio',
+      'settingsRebuildAudioTiming': 'Reconstruir timing de audio',
+      'settingsRebuildAudioTimingSubtitle': 'Recalcula la sincronización de subtítulos para todas las lecciones',
+      'settingsForceAudioRegen': 'Forzar re-generación de audio',
+      'settingsForceAudioRegenSubtitle': 'Vuelve a ejecutar TTS para cada lección (lento). Desactiva para solo recalcular el timing de los archivos existentes.',
+      'settingsJobStarted': 'Iniciado — esto puede tardar varios minutos',
+      'settingsJobError': 'Error: {error}',
+      'statsTitle': 'Estadísticas y racha',
+      'dayStreak': 'días de racha',
+      'reviewedToday': '✓ {count} revisado(s) hoy',
+      'noReviewsToday': 'Sin revisiones hoy',
+      'statsOverview': 'Resumen',
+      'statsTotalReviews': 'Total de revisiones',
+      'statsReviewedTodayLabel': 'Revisado hoy',
+      'statsNoScores': 'Aún no hay puntuaciones registradas.',
+      'statsScoreDistribution': 'Distribución de puntuaciones',
     },
   };
 }

--- a/android_app/lib/main.dart
+++ b/android_app/lib/main.dart
@@ -11,6 +11,7 @@ import 'screens/diary_screen.dart';
 import 'screens/lessons_screen.dart';
 import 'screens/sentences_screen.dart';
 import 'screens/settings_screen.dart';
+import 'screens/player_screen.dart';
 import 'screens/native_first_sentences_screen.dart';
 import 'widgets/connection_badge.dart';
 import 'widgets/scaled_app.dart';
@@ -70,6 +71,14 @@ final _router = GoRouter(
            name: 'nativeFirstReview',
            builder: (_, __) => const NativeFirstSentencesScreen()),
        GoRoute(path: '/lessons', name: 'lessons', builder: (_, __) => const LessonsScreen()),
+       GoRoute(
+         path: '/lessons/player',
+         name: 'player',
+         builder: (_, state) {
+           final lesson = state.extra as Map<String, dynamic>? ?? {};
+           return PlayerScreen(lesson: lesson);
+         },
+       ),
        GoRoute(path: '/diary', name: 'diary', builder: (_, __) => const DiaryScreen()),
        GoRoute(path: '/settings', name: 'settings', builder: (_, __) => const SettingsScreen()),
      ],

--- a/android_app/lib/main.dart
+++ b/android_app/lib/main.dart
@@ -184,18 +184,19 @@ class MainShell extends StatelessWidget {
       listenable: SyncManager.instance,
       builder: (context, _) {
         final sync = SyncManager.instance;
+        final l10n = AppLocalizations.of(context);
         return Scaffold(
           appBar: AppBar(
             title: const Text('LingoDiary'),
             actions: [
               const ConnectionBadge(),
               IconButton(
-                tooltip: 'Help',
+                tooltip: l10n.helpTooltip,
                 icon: const Icon(Icons.help_outline),
                 onPressed: () => _showHelpDialog(context),
               ),
               IconButton(
-                tooltip: 'Settings',
+                tooltip: l10n.settingsTooltip,
                 icon: const Icon(Icons.settings_outlined),
                 onPressed: () => context.push('/settings'),
               ),
@@ -246,8 +247,8 @@ class MainShell extends StatelessWidget {
                         style: TextButton.styleFrom(
                             padding: EdgeInsets.zero,
                             minimumSize: const Size(48, 28)),
-                        child: const Text('Cancel',
-                            style: TextStyle(color: Colors.red)),
+                        child: Text(l10n.cancelButton,
+                            style: const TextStyle(color: Colors.red)),
                       ),
                     ],
                   ),
@@ -287,15 +288,15 @@ class MainShell extends StatelessWidget {
                 type: BottomNavigationBarType.fixed,
                 items: [
                   BottomNavigationBarItem(
-                      icon: const Icon(Icons.home_outlined), label: 'Home'),
+                      icon: const Icon(Icons.home_outlined), label: l10n.navHome),
                   BottomNavigationBarItem(
-                      icon: const Icon(Icons.quiz_outlined), label: 'Review'),
+                      icon: const Icon(Icons.quiz_outlined), label: l10n.navReview),
                   BottomNavigationBarItem(
                       icon: const Icon(Icons.headphones),
-                      label: AppLocalizations.of(context).navLessons),
+                      label: l10n.navLessons),
                   BottomNavigationBarItem(
                       icon: const Icon(Icons.book),
-                      label: AppLocalizations.of(context).navDiary),
+                      label: l10n.navDiary),
                 ],
               ),
             ],

--- a/android_app/lib/screens/diary_screen.dart
+++ b/android_app/lib/screens/diary_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../l10n/app_localizations.dart';
 import '../services/api_service.dart';
 import '../services/local_db_service.dart';
 
@@ -86,8 +87,9 @@ class _DiaryScreenState extends State<DiaryScreen> {
   // ── save to server ────────────────────────────────────────────────────────────
 
   Future<void> _saveEntry() async {
+    final l10n = AppLocalizations.of(context);
     if (_sentences.isEmpty) {
-      setState(() => _error = 'Add at least one sentence first.');
+      setState(() => _error = l10n.diaryAddSentenceFirst);
       return;
     }
     setState(() {
@@ -102,8 +104,9 @@ class _DiaryScreenState extends State<DiaryScreen> {
       // Also cache locally
       final entryText = _sentences.map((s) => '- $s').join('\n');
       await LocalDbService.saveDiaryContent('[$dateStr]\n$entryText');
+      final count = _sentences.length;
       setState(() {
-        _successMessage = '✓ Entry saved for $dateStr (${_sentences.length} sentence(s))';
+        _successMessage = l10n.diaryEntrySaved(dateStr, count);
         _sentences.clear();
         _editingIndex = -1;
       });
@@ -112,7 +115,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
       final entryText = _sentences.map((s) => '- $s').join('\n');
       await LocalDbService.saveDiaryContent('[$dateStr]\n$entryText');
       if (mounted) {
-        setState(() => _error = 'Saved locally. Will sync on next connection.\n$e');
+        setState(() => _error = l10n.diarySavedLocally(e.toString()));
       }
     } finally {
       if (mounted) setState(() => _saving = false);
@@ -122,9 +125,10 @@ class _DiaryScreenState extends State<DiaryScreen> {
   // ── generate lessons ─────────────────────────────────────────────────────────
 
   Future<void> _generateLessons() async {
+    final l10n = AppLocalizations.of(context);
     setState(() {
       _generating = true;
-      _generateLog = 'Starting generation…\n';
+      _generateLog = '${l10n.diaryGenerationStarting}\n';
       _logOffset = 0;
       _error = null;
     });
@@ -141,7 +145,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
         if (result['done'] as bool) break;
       }
     } catch (e) {
-      setState(() => _error = 'Could not connect to server.');
+      setState(() => _error = l10n.diaryCouldNotConnect);
     } finally {
       if (mounted) setState(() => _generating = false);
     }
@@ -162,6 +166,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
       child: Column(
@@ -171,19 +176,19 @@ class _DiaryScreenState extends State<DiaryScreen> {
           Card(
             child: ListTile(
               leading: const Icon(Icons.calendar_today, color: Colors.indigo),
-              title: const Text('Diary date'),
+              title: Text(l10n.diaryDate),
               subtitle: Text(_dateLabel,
                   style: const TextStyle(fontWeight: FontWeight.bold)),
               trailing: TextButton(
                 onPressed: _pickDate,
-                child: const Text('Change'),
+                child: Text(l10n.changeButton),
               ),
             ),
           ),
           const SizedBox(height: 12),
 
           // ── Sentence input ──────────────────────────────────────────────────
-          Text('Sentences for $_dateLabel',
+          Text(l10n.diarySentencesFor(_dateLabel),
               style: Theme.of(context).textTheme.titleSmall),
           const SizedBox(height: 8),
           Row(
@@ -192,8 +197,8 @@ class _DiaryScreenState extends State<DiaryScreen> {
                 child: TextField(
                   controller: _sentenceController,
                   focusNode: _sentenceFocusNode,
-                  decoration: const InputDecoration(
-                    hintText: 'Type a sentence…',
+                  decoration: InputDecoration(
+                    hintText: l10n.diaryTypeSentenceHint,
                     border: OutlineInputBorder(),
                     isDense: true,
                     contentPadding:
@@ -207,7 +212,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
               FilledButton.icon(
                 onPressed: _addSentence,
                 icon: const Icon(Icons.add, size: 18),
-                label: const Text('Add'),
+                label: Text(l10n.addButton),
               ),
             ],
           ),
@@ -249,12 +254,12 @@ class _DiaryScreenState extends State<DiaryScreen> {
                       children: [
                         IconButton(
                           icon: const Icon(Icons.edit, size: 16),
-                          tooltip: 'Edit',
+                          tooltip: l10n.editTooltip,
                           onPressed: () => _startEditing(i),
                         ),
                         IconButton(
                           icon: const Icon(Icons.close, size: 16),
-                          tooltip: 'Remove',
+                          tooltip: l10n.removeTooltip,
                           onPressed: () => _removeSentence(i),
                         ),
                       ],
@@ -273,7 +278,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
                     width: 16,
                     child: CircularProgressIndicator(strokeWidth: 2))
                 : const Icon(Icons.cloud_upload),
-            label: const Text('Save to Server'),
+            label: Text(l10n.diarySaveToServer),
             style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.indigo,
                 foregroundColor: Colors.white),
@@ -315,7 +320,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
                     width: 16,
                     child: CircularProgressIndicator(strokeWidth: 2))
                 : const Icon(Icons.play_arrow),
-            label: const Text('Generate Lessons'),
+            label: Text(l10n.diaryGenerateLessons),
             style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.green, foregroundColor: Colors.white),
           ),
@@ -368,7 +373,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
           ),
           IconButton(
             icon: const Icon(Icons.check, color: Colors.green),
-            tooltip: 'Confirm',
+            tooltip: AppLocalizations.of(context).confirmTooltip,
             onPressed: () => _commitEdit(index),
           ),
           IconButton(

--- a/android_app/lib/screens/home_screen.dart
+++ b/android_app/lib/screens/home_screen.dart
@@ -67,20 +67,21 @@ class _HomeScreenState extends State<HomeScreen> {
       return const Center(child: CircularProgressIndicator());
     }
     if (_error != null && _homeData == null) {
+      final l10n = AppLocalizations.of(context);
       return Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             const Icon(Icons.wifi_off, size: 48, color: Colors.grey),
             const SizedBox(height: 12),
-            Text(_error!, style: const TextStyle(color: Colors.grey)),
+            Text(l10n.serverUnreachableNoCache, style: const TextStyle(color: Colors.grey)),
             const SizedBox(height: 16),
             ElevatedButton(
                 onPressed: () {
                   setState(() => _loading = true);
                   _loadData();
                 },
-                child: const Text('Retry')),
+                child: Text(l10n.retryButton)),
           ],
         ),
       );
@@ -169,6 +170,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _buildStatsCard() {
+    final l10n = AppLocalizations.of(context);
     final stats = _homeData?['stats'] as Map<String, dynamic>? ?? {};
     final total = (stats['total'] as int?) ?? 0;
     final mastered = (stats['mastered'] as int?) ?? 0;
@@ -184,10 +186,10 @@ class _HomeScreenState extends State<HomeScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Progress', style: Theme.of(context).textTheme.titleMedium),
+            Text(l10n.homeProgress, style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 12),
             _progressRow(
-              label: 'Mastered',
+              label: l10n.homeMastered,
               count: mastered,
               total: total,
               value: masteredFrac,
@@ -195,7 +197,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
             const SizedBox(height: 8),
             _progressRow(
-              label: 'In progress',
+              label: l10n.homeInProgress,
               count: learning,
               total: total,
               value: learningFrac,
@@ -203,7 +205,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
             const SizedBox(height: 8),
             Text(
-              '$newCount new • $total total entries',
+              l10n.homeNewTotalEntries(newCount, total),
               style: const TextStyle(fontSize: 12, color: Colors.grey),
             ),
           ],
@@ -248,7 +250,8 @@ class _HomeScreenState extends State<HomeScreen> {
     final title = rec['title'] as String? ?? rec['date'] as String? ?? '?';
     final variant = rec['variant'] as String? ?? 'original';
     final reason = rec['reason'] as String? ?? '';
-    final reasonLabel = reason == 'due_for_review' ? 'Due for review' : 'New lesson';
+    final l10n = AppLocalizations.of(context);
+    final reasonLabel = reason == 'due_for_review' ? l10n.dueForReview : l10n.newLesson;
 
     return InkWell(
       onTap: () {
@@ -267,14 +270,14 @@ class _HomeScreenState extends State<HomeScreen> {
                   const Icon(Icons.push_pin, size: 18),
                   const SizedBox(width: 6),
                   Expanded(
-                    child: Text('Study Now',
+                    child: Text(l10n.homeStudyNow,
                         style: Theme.of(context)
                             .textTheme
                             .titleMedium
                             ?.copyWith(fontWeight: FontWeight.bold)),
                   ),
                   PopupMenuButton<String>(
-                    tooltip: 'Review options',
+                    tooltip: l10n.reviewOptionsTooltip,
                     icon: const Icon(Icons.headphones, size: 16),
                     onSelected: (value) {
                       if (value == 'original') {
@@ -284,20 +287,20 @@ class _HomeScreenState extends State<HomeScreen> {
                       }
                     },
                     itemBuilder: (context) => [
-                      const PopupMenuItem(
+                      PopupMenuItem(
                         value: 'original',
                         child: ListTile(
-                          leading: Icon(Icons.rate_review_outlined),
-                          title: Text('Original Review'),
+                          leading: const Icon(Icons.rate_review_outlined),
+                          title: Text(l10n.originalReview),
                           contentPadding: EdgeInsets.zero,
                           dense: true,
                         ),
                       ),
-                      const PopupMenuItem(
+                      PopupMenuItem(
                         value: 'translation',
                         child: ListTile(
-                          leading: Icon(Icons.translate_outlined),
-                          title: Text('Translation Excercise'),
+                          leading: const Icon(Icons.translate_outlined),
+                          title: Text(l10n.translationExercise),
                           contentPadding: EdgeInsets.zero,
                           dense: true,
                         ),
@@ -328,18 +331,19 @@ class _HomeScreenState extends State<HomeScreen> {
     final recent =
         (_homeData?['recent_lessons'] as List?)?.cast<Map<String, dynamic>>() ?? [];
 
+    final l10n = AppLocalizations.of(context);
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Recently Studied',
+            Text(l10n.homeRecentlyStudied,
                 style: Theme.of(context).textTheme.titleMedium),
             const Divider(),
             if (recent.isEmpty)
-              const Text('No lessons studied yet.',
-                  style: TextStyle(color: Colors.grey))
+              Text(l10n.homeNoLessonsStudied,
+                  style: const TextStyle(color: Colors.grey))
             else
               ...recent.map((item) => _recentTile(item)),
           ],
@@ -349,6 +353,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _recentTile(Map<String, dynamic> item) {
+    final l10n = AppLocalizations.of(context);
     final date = item['date'] as String? ?? '';
     final title = item['title'] as String? ?? date;
     final lastReviewed = item['last_reviewed'] as String? ?? '';
@@ -363,13 +368,13 @@ class _HomeScreenState extends State<HomeScreen> {
         final diff = now.difference(reviewTime);
 
         if (diff.inDays > 0) {
-          timeAgo = '${diff.inDays}d ago';
+          timeAgo = l10n.timeAgoDays(diff.inDays);
         } else if (diff.inHours > 0) {
-          timeAgo = '${diff.inHours}h ago';
+          timeAgo = l10n.timeAgoHours(diff.inHours);
         } else if (diff.inMinutes > 0) {
-          timeAgo = '${diff.inMinutes}m ago';
+          timeAgo = l10n.timeAgoMinutes(diff.inMinutes);
         } else {
-          timeAgo = 'Just now';
+          timeAgo = l10n.timeAgoJustNow;
         }
       } catch (_) {
         timeAgo = '';

--- a/android_app/lib/screens/lessons_screen.dart
+++ b/android_app/lib/screens/lessons_screen.dart
@@ -2,11 +2,11 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import '../services/api_service.dart';
 import '../services/local_db_service.dart';
 import '../services/sync_manager.dart';
 import '../services/sync_service.dart';
-import 'player_screen.dart';
 
 class LessonsScreen extends StatefulWidget {
   const LessonsScreen({super.key});
@@ -156,10 +156,7 @@ class _LessonsScreenState extends State<LessonsScreen> {
   }
 
   void _openLesson(Map<String, dynamic> lesson) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => PlayerScreen(lesson: lesson)),
-    );
+    context.push('/lessons/player', extra: lesson);
   }
 
   @override

--- a/android_app/lib/screens/lessons_screen.dart
+++ b/android_app/lib/screens/lessons_screen.dart
@@ -7,6 +7,7 @@ import '../services/api_service.dart';
 import '../services/local_db_service.dart';
 import '../services/sync_manager.dart';
 import '../services/sync_service.dart';
+import '../l10n/app_localizations.dart';
 
 class LessonsScreen extends StatefulWidget {
   const LessonsScreen({super.key});
@@ -145,7 +146,7 @@ class _LessonsScreenState extends State<LessonsScreen> {
       final total = (srs['total'] as int?) ?? 0;
       final mastered = (srs['mastered'] as int?) ?? 0;
       return Text(
-        '$variantStr  ·  $mastered/$total mastered',
+        '$variantStr  ·  ${AppLocalizations.of(context).lessonsMasteredCount(mastered, total)}',
         style: const TextStyle(fontSize: 12, color: Colors.grey),
       );
     }
@@ -188,13 +189,13 @@ class _LessonsScreenState extends State<LessonsScreen> {
                           onPressed: SyncManager.instance.cancel,
                           icon: const Icon(Icons.stop,
                               size: 16, color: Colors.red),
-                          label: const Text('Cancel',
-                              style: TextStyle(color: Colors.red)),
+                          label: Text(AppLocalizations.of(context).cancelButton,
+                              style: const TextStyle(color: Colors.red)),
                         )
                       : ElevatedButton.icon(
                           onPressed: SyncManager.instance.syncAll,
                           icon: const Icon(Icons.sync, size: 16),
-                          label: const Text('Sync All'),
+                          label: Text(AppLocalizations.of(context).syncAll),
                         );
                 },
               ),
@@ -205,9 +206,9 @@ class _LessonsScreenState extends State<LessonsScreen> {
           child: _loading
               ? const Center(child: CircularProgressIndicator())
               : _lessons.isEmpty
-                  ? const Center(
+                  ? Center(
                       child: Text(
-                          'No lessons yet.\nTap Sync All to download.',
+                          AppLocalizations.of(context).noLessons,
                           textAlign: TextAlign.center))
                   : RefreshIndicator(
                       onRefresh: _onRefresh,

--- a/android_app/lib/screens/login_screen.dart
+++ b/android_app/lib/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
+import '../l10n/app_localizations.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -68,7 +69,7 @@ class _LoginScreenState extends State<LoginScreen> {
     } on ApiException catch (e) {
       setState(() => _error = e.message);
     } catch (e) {
-      setState(() => _error = 'Error: $e\n\nCheck the server URL is correct and the server is reachable.');
+      setState(() => _error = AppLocalizations.of(context).loginConnectionError(e.toString()));
     } finally {
       if (mounted) setState(() => _loading = false);
     }
@@ -76,6 +77,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       body: SafeArea(
         child: Center(
@@ -96,36 +98,36 @@ class _LoginScreenState extends State<LoginScreen> {
                   if (!kIsWeb) ...[
                     TextFormField(
                       controller: _serverController,
-                      decoration: const InputDecoration(
-                        labelText: 'Server URL',
-                        hintText: 'http://192.168.1.x:8084',
+                      decoration: InputDecoration(
+                        labelText: l10n.loginServerUrl,
+                        hintText: l10n.loginServerHint,
                         border: OutlineInputBorder(),
                       ),
                       keyboardType: TextInputType.url,
                       validator: (v) =>
-                          (v == null || v.isEmpty) ? 'Enter the server URL' : null,
+                          (v == null || v.isEmpty) ? l10n.loginServerRequired : null,
                     ),
                     const SizedBox(height: 12),
                   ],
                   TextFormField(
                     controller: _usernameController,
-                    decoration: const InputDecoration(
-                      labelText: 'Username',
+                    decoration: InputDecoration(
+                      labelText: l10n.loginUsername,
                       border: OutlineInputBorder(),
                     ),
                     validator: (v) =>
-                        (v == null || v.isEmpty) ? 'Enter username' : null,
+                        (v == null || v.isEmpty) ? l10n.loginUsernameRequired : null,
                   ),
                   const SizedBox(height: 12),
                   TextFormField(
                     controller: _passwordController,
-                    decoration: const InputDecoration(
-                      labelText: 'Password',
+                    decoration: InputDecoration(
+                      labelText: l10n.loginPassword,
                       border: OutlineInputBorder(),
                     ),
                     obscureText: true,
                     validator: (v) =>
-                        (v == null || v.isEmpty) ? 'Enter password' : null,
+                        (v == null || v.isEmpty) ? l10n.loginPasswordRequired : null,
                   ),
                   if (_error != null) ...[
                     const SizedBox(height: 12),

--- a/android_app/lib/screens/native_first_sentences_screen.dart
+++ b/android_app/lib/screens/native_first_sentences_screen.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../services/api_service.dart';
 import '../services/local_db_service.dart';
 import '../services/sync_service.dart';
+import '../l10n/app_localizations.dart';
 import 'stats_screen.dart';
 
 /// A screen that shows native (input) text for each sentence first,
@@ -295,8 +296,8 @@ class _NativeFirstSentencesScreenState
       setState(() => _syncing = false);
       _loadAudio();
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-            content: Text('Audio synced'), duration: Duration(seconds: 2)),
+        SnackBar(
+            content: Text(AppLocalizations.of(context).audioSynced), duration: const Duration(seconds: 2)),
       );
     }
   }
@@ -315,7 +316,7 @@ class _NativeFirstSentencesScreenState
       _loadAudio();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Synced audio for $count sentences'),
+          content: Text(AppLocalizations.of(context).syncedAudioCount(count)),
           duration: const Duration(seconds: 3),
         ),
       );
@@ -384,6 +385,7 @@ class _NativeFirstSentencesScreenState
 
   Future<void> _score(int score) async {
     if (_scoring) return;
+    final l10n = AppLocalizations.of(context);
     setState(() => _scoring = true);
     final item = _sentences[_currentIndex];
     final date = item['date'] as String? ?? '';
@@ -410,8 +412,8 @@ class _NativeFirstSentencesScreenState
             e.toString().contains('TimeoutException');
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(isOffline
-              ? 'Score saved (will sync when online)'
-              : 'Score saved locally — sync error: $e'),
+              ? l10n.scoreSavedWillSync
+              : l10n.scoreSavedLocallyError(e.toString())),
           duration: const Duration(seconds: 2),
         ));
       }
@@ -437,6 +439,7 @@ class _NativeFirstSentencesScreenState
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }
@@ -449,12 +452,12 @@ class _NativeFirstSentencesScreenState
             children: [
               const Icon(Icons.cloud_off, size: 48, color: Colors.grey),
               const SizedBox(height: 12),
-              Text(_error!, textAlign: TextAlign.center),
+              Text(l10n.offlineLoadNewSentences, textAlign: TextAlign.center),
               const SizedBox(height: 16),
               ElevatedButton.icon(
                 onPressed: _loadSentences,
                 icon: const Icon(Icons.refresh),
-                label: const Text('Retry'),
+                label: Text(l10n.retryButton),
               ),
             ],
           ),
@@ -471,21 +474,21 @@ class _NativeFirstSentencesScreenState
               const Icon(Icons.check_circle_outline,
                   size: 64, color: Colors.green),
               const SizedBox(height: 16),
-              const Text(
-                'All caught up!',
-                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              Text(
+                l10n.allCaughtUp,
+                style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 8),
-              const Text(
-                'No sentences due for review right now.',
+              Text(
+                l10n.noSentencesDue,
                 textAlign: TextAlign.center,
-                style: TextStyle(color: Colors.grey),
+                style: const TextStyle(color: Colors.grey),
               ),
               const SizedBox(height: 20),
               ElevatedButton.icon(
                 onPressed: _loadSentences,
                 icon: const Icon(Icons.refresh),
-                label: const Text('Refresh'),
+                label: Text(l10n.refreshButton),
               ),
             ],
           ),
@@ -507,7 +510,7 @@ class _NativeFirstSentencesScreenState
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Translation Excercise'),
+        title: Text(l10n.translationExerciseTitle),
         actions: [
           _syncing
               ? const Padding(
@@ -548,7 +551,7 @@ class _NativeFirstSentencesScreenState
                   ],
                 ),
           IconButton(
-            tooltip: 'Stats & Streak',
+            tooltip: l10n.statsAndStreakTooltip,
             icon: const Icon(Icons.bar_chart_outlined),
             onPressed: () => Navigator.push(
               context,
@@ -628,7 +631,7 @@ class _NativeFirstSentencesScreenState
             padding: const EdgeInsets.only(right: 16),
             child: Center(
               child: Text(
-                '$remaining left',
+                l10n.reviewRemaining(remaining),
                 style: const TextStyle(fontSize: 13, color: Colors.grey),
               ),
             ),
@@ -763,7 +766,7 @@ class _NativeFirstSentencesScreenState
                                             controller: _sentenceInputController,
                                             focusNode: _sentenceFocusNode,
                                             decoration: InputDecoration(
-                                              labelText: 'Your translation attempt (press Enter to reveal)',
+                                              labelText: l10n.translationAttemptHintWithEnter,
                                               labelStyle: TextStyle(fontSize: 14 * _fontSizeScale),
                                               border: const OutlineInputBorder(),
                                             ),
@@ -846,8 +849,8 @@ class _NativeFirstSentencesScreenState
                                           ),
                                         ),
                                       if (_audioDownloading)
-                                        const Text(
-                                          'Downloading audio…',
+                                        Text(
+                                          l10n.downloadingAudio,
                                           style: TextStyle(
                                               fontSize: 11, color: Colors.grey),
                                         )
@@ -855,8 +858,8 @@ class _NativeFirstSentencesScreenState
                                         Row(
                                           mainAxisSize: MainAxisSize.min,
                                           children: [
-                                            const Text(
-                                              'Audio unavailable',
+                                            Text(
+                                              l10n.audioUnavailable,
                                               style: TextStyle(
                                                   fontSize: 11, color: Colors.grey),
                                             ),
@@ -1147,25 +1150,25 @@ class _NativeFirstSentencesScreenState
             ),
             child: Column(
               children: [
-                const Text(
-                  'How well did you remember?',
+                Text(
+                  l10n.howWellDidYouRemember,
                   style: TextStyle(fontSize: 12, color: Colors.grey),
                 ),
                 const SizedBox(height: 8),
                 Row(
                   children: [
-                    _scoreButton('Again', 0, Colors.red),
-                    _scoreButton('Hard', 2, Colors.orange),
-                    _scoreButton('Good', 3, Colors.blue),
-                    _scoreButton('Easy', 5, Colors.green),
+                    _scoreButton(l10n.scoreAgain, 0, Colors.red),
+                    _scoreButton(l10n.scoreHard, 2, Colors.orange),
+                    _scoreButton(l10n.scoreGood, 3, Colors.blue),
+                    _scoreButton(l10n.scoreEasy, 5, Colors.green),
                   ],
                 ),
                 const SizedBox(height: 4),
                 TextButton(
                   onPressed: _scoring ? null : _next,
-                  child: const Text(
-                    'Skip',
-                    style: TextStyle(fontSize: 12, color: Colors.grey),
+                  child: Text(
+                    l10n.skipButton,
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
                   ),
                 ),
               ],

--- a/android_app/lib/screens/player_screen.dart
+++ b/android_app/lib/screens/player_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -25,8 +24,7 @@ class PlayerScreen extends StatefulWidget {
 
 class _PlayerScreenState extends State<PlayerScreen> {
   /// Safe int coercion: handles JSON values that may arrive as double (e.g.
-  /// audio_timing.start_ms / end_ms were stored as floats in older diary.json
-  /// files produced by audio_timing.py before the int-cast fix).
+  /// audio_timing.start_ms / end_ms stored as floats in older data).
   static int _toInt(dynamic v) {
     if (v is int) return v;
     if (v is double) return v.round();
@@ -105,7 +103,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _tabNames = [...orderedVariants, ...extras, _kInputDiaryTab];
     _currentTab = _tabNames.isNotEmpty ? _tabNames.first : _kInputDiaryTab;
 
-    // Prefer date field from server (diary.json); fall back to parsing base name.
+    // Prefer date field from server; fall back to parsing base name.
     final base = widget.lesson['base'] as String? ?? '';
     _lessonDate = widget.lesson['date'] as String? ??
         RegExp(r'TPRS_(\d{4}-\d{2}-\d{2})').firstMatch(base)?.group(1);
@@ -219,75 +217,63 @@ class _PlayerScreenState extends State<PlayerScreen> {
     await _tryLoadAudio(variantName);
 
     // Fetch structured entries (timings + translations).
-    // Strategy: load local diary.json immediately (instant), then try the API
-    // in the background and update if fresher data arrives.
+    // Strategy: load from day_cache SQLite immediately (instant, offline),
+    // then fetch full day data from the API in the background and update cache.
     if (_lessonDate != null) {
       final variantKey = _variantToApiKey(variantName);
 
-      // Local-first: instant display from cached diary.json.
+      // Local-first: instant display from day_cache SQLite.
       if (_sentenceEntries.isEmpty) {
-        await _loadEntriesFromLocalJson(variantKey);
+        await _loadEntriesFromDayCache(variantKey);
       }
 
-      // Background API refresh (does not block UI or delay text display).
-      ApiService.getLessonEntries(_lessonDate!, variantKey).then((data) {
-        final entries =
-            (data['entries'] as List?)?.cast<Map<String, dynamic>>() ?? [];
-        if (mounted && entries.isNotEmpty) {
-          _applyEntries(entries);
+      // Background API refresh — fetches full day data and updates day_cache.
+      ApiService.getDayData(_lessonDate!).then((dayData) {
+        if (mounted) {
+          LocalDbService.saveDayCache(_lessonDate!, dayData).catchError((_) {});
+          _applyEntriesFromDayData(dayData, variantKey);
         }
       }).catchError((_) {
-        // Server unreachable — local data already shown, nothing to do.
+        // Server unreachable — local cache already shown, nothing to do.
       });
     }
   }
 
-  /// Parse entries for [variantKey] from the locally cached diary.json.
-  /// On web there is no local file cache — this is skipped and the server
+  /// Load entries for [variantKey] from the local day_cache SQLite table.
+  /// On web there is no local cache — this is skipped and the server
   /// data (already loaded via the API) is used instead.
-  Future<void> _loadEntriesFromLocalJson(String variantKey) async {
+  Future<void> _loadEntriesFromDayCache(String variantKey) async {
     if (_lessonDate == null || kIsWeb) return;
     try {
-      final jsonPath = await SyncService.localPath('diary.json');
-      final jsonFile = File(jsonPath);
-      if (!await jsonFile.exists()) return;
-
-      final data = json.decode(await jsonFile.readAsString()) as Map<String, dynamic>;
-      final diaries = (data['diaries'] as List?) ?? [];
-
-      // diary.json dates are stored as YYYY/MM/DD; _lessonDate is YYYY-MM-DD
-      final lessonDateSlash = _lessonDate!.replaceAll('-', '/');
-      Map<String, dynamic>? day;
-      for (final d in diaries) {
-        if ((d as Map<String, dynamic>)['date'] == lessonDateSlash) {
-          day = d;
-          break;
-        }
-      }
-      if (day == null) return;
-
-      final rawEntries = (day['entries'] as List?) ?? [];
-      final entries = rawEntries.map((e) {
-        final em = e as Map<String, dynamic>;
-        final lesson = (em['lessons'] as Map<String, dynamic>?)?[variantKey]
-            as Map<String, dynamic>? ?? {};
-        return <String, dynamic>{
-          'index': em['index'],  // preserve 1-based index for correct scoring
-          'sentence': lesson['sentence'] ?? '',
-          'sentence_input': lesson['sentence_input'] ?? '',
-          'input_language_sentence': em['input_language_sentence'] ?? '',
-          'output_language_translation': em['output_language_translation'] ?? '',
-          'audio_timing': lesson['audio_timing'],
-          'qa': lesson['qa'] ?? [],
-        };
-      }).cast<Map<String, dynamic>>().toList();
-
-      if (mounted && entries.isNotEmpty) {
-        _applyEntries(entries);
-      }
+      final dayData = await LocalDbService.getDayCache(_lessonDate!);
+      if (dayData == null) return;
+      _applyEntriesFromDayData(dayData, variantKey);
     } catch (e, st) {
-      // Corrupt or missing local cache — show nothing (error logged for debugging)
-      debugPrint('_loadEntriesFromLocalJson error: $e\n$st');
+      debugPrint('_loadEntriesFromDayCache error: $e\n$st');
+    }
+  }
+
+  /// Extract and apply entries for [variantKey] from a full Day object.
+  void _applyEntriesFromDayData(Map<String, dynamic> dayData, String variantKey) {
+    final rawEntries = (dayData['entries'] as List?) ?? [];
+    final entries = rawEntries.map((e) {
+      final em = e as Map<String, dynamic>;
+      final lesson = (em['lessons'] as Map<String, dynamic>?)?[variantKey]
+          as Map<String, dynamic>? ?? {};
+      return <String, dynamic>{
+        'index': em['index'],
+        'sentence': lesson['sentence'] ?? '',
+        'sentence_input': lesson['sentence_input'] ?? '',
+        'input_language_sentence': em['input_language_sentence'] ?? '',
+        'output_language_translation': em['output_language_translation'] ?? '',
+        'audio_timing': lesson['audio_timing'],
+        'qa': lesson['qa'] ?? [],
+        'reviewing': (em['lessons'] as Map<String, dynamic>?)?['reviewing'],
+      };
+    }).cast<Map<String, dynamic>>().toList();
+
+    if (mounted && entries.isNotEmpty) {
+      _applyEntries(entries);
     }
   }
 
@@ -639,7 +625,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   void _triggerSync() {
     final base = widget.lesson['base'] as String;
-    SyncManager.instance.syncLesson(base);
+    SyncManager.instance.syncLesson(base, date: _lessonDate);
   }
 
   @override

--- a/android_app/lib/screens/player_screen.dart
+++ b/android_app/lib/screens/player_screen.dart
@@ -104,10 +104,10 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _tabNames = [...orderedVariants, ...extras, _kInputDiaryTab];
     _currentTab = _tabNames.isNotEmpty ? _tabNames.first : _kInputDiaryTab;
 
-    // Extract YYYY-MM-DD from base name (e.g. …_TPRS_2026-01-21_…)
+    // Prefer date field from server (diary.json); fall back to parsing base name.
     final base = widget.lesson['base'] as String? ?? '';
-    final m = RegExp(r'_TPRS_(\d{4}-\d{2}-\d{2})').firstMatch(base);
-    _lessonDate = m?.group(1);
+    _lessonDate = widget.lesson['date'] as String? ??
+        RegExp(r'TPRS_(\d{4}-\d{2}-\d{2})').firstMatch(base)?.group(1);
 
     _loadKeywords().then((_) {
       if (_currentTab != _kInputDiaryTab) {

--- a/android_app/lib/screens/player_screen.dart
+++ b/android_app/lib/screens/player_screen.dart
@@ -9,6 +9,7 @@ import '../services/api_service.dart';
 import '../services/local_db_service.dart';
 import '../services/sync_manager.dart';
 import '../services/sync_service.dart';
+import '../l10n/app_localizations.dart';
 
 /// Synthetic tab name for the "Input Diary" view (no audio).
 const _kInputDiaryTab = 'Input Diary';
@@ -1029,6 +1030,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final title = widget.lesson['display'] as String? ?? '';
     final isInputDiary = _currentTab == _kInputDiaryTab;
 
@@ -1038,13 +1040,13 @@ class _PlayerScreenState extends State<PlayerScreen> {
         actions: [
           // Font size cycle button
           IconButton(
-            tooltip: 'Font size (${_fontSize.toStringAsFixed(0)})',
+            tooltip: l10n.fontSizeTooltip(_fontSize.toStringAsFixed(0)),
             icon: const Icon(Icons.text_fields),
             onPressed: _cycleFontSize,
           ),
           // Loop toggle
           IconButton(
-            tooltip: _loopEnabled ? 'Loop: on' : 'Loop: off',
+            tooltip: _loopEnabled ? l10n.loopOn : l10n.loopOff,
             icon: Icon(
               _loopEnabled ? Icons.repeat_one : Icons.repeat,
               color: _loopEnabled ? Colors.blue.shade400 : null,
@@ -1223,7 +1225,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       IconButton(
-                        tooltip: 'Previous block',
+                        tooltip: l10n.previousBlock,
                         icon: const Icon(Icons.skip_previous),
                         onPressed: _audioReady && _entrySpans.isNotEmpty
                             ? _prevBlock
@@ -1297,7 +1299,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
                             : null,
                       ),
                       IconButton(
-                        tooltip: 'Next block',
+                        tooltip: l10n.nextBlock,
                         icon: const Icon(Icons.skip_next),
                         onPressed: _audioReady && _entrySpans.isNotEmpty
                             ? _nextBlock

--- a/android_app/lib/screens/sentences_screen.dart
+++ b/android_app/lib/screens/sentences_screen.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../services/api_service.dart';
 import '../services/local_db_service.dart';
 import '../services/sync_service.dart';
+import '../l10n/app_localizations.dart';
 import 'stats_screen.dart';
 
 /// Anki-style sentence review screen.
@@ -296,7 +297,7 @@ class _SentencesScreenState extends State<SentencesScreen> {
       _loadAudio();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Synced audio for $count sentences'),
+          content: Text(AppLocalizations.of(context).syncedAudioCount(count)),
           duration: const Duration(seconds: 3),
         ),
       );
@@ -346,6 +347,7 @@ class _SentencesScreenState extends State<SentencesScreen> {
 
   Future<void> _score(int score) async {
     if (_scoring) return;
+    final l10n = AppLocalizations.of(context);
     setState(() => _scoring = true);
     final item = _sentences[_currentIndex];
     final date = item['date'] as String? ?? '';
@@ -379,8 +381,8 @@ class _SentencesScreenState extends State<SentencesScreen> {
             e.toString().contains('TimeoutException');
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(isOffline
-              ? 'Score saved (will sync when online)'
-              : 'Score saved locally — sync error: $e'),
+              ? l10n.scoreSavedWillSync
+              : l10n.scoreSavedLocallyError(e.toString())),
           duration: const Duration(seconds: 2),
         ));
       }
@@ -406,6 +408,7 @@ class _SentencesScreenState extends State<SentencesScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }
@@ -418,12 +421,12 @@ class _SentencesScreenState extends State<SentencesScreen> {
             children: [
               const Icon(Icons.cloud_off, size: 48, color: Colors.grey),
               const SizedBox(height: 12),
-              Text(_error!, textAlign: TextAlign.center),
+              Text(l10n.offlineLoadNewSentences, textAlign: TextAlign.center),
               const SizedBox(height: 16),
               ElevatedButton.icon(
                 onPressed: _loadSentences,
                 icon: const Icon(Icons.refresh),
-                label: const Text('Retry'),
+                label: Text(l10n.retryButton),
               ),
             ],
           ),
@@ -439,21 +442,21 @@ class _SentencesScreenState extends State<SentencesScreen> {
             children: [
               const Icon(Icons.check_circle_outline, size: 64, color: Colors.green),
               const SizedBox(height: 16),
-              const Text(
-                'All caught up!',
-                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              Text(
+                l10n.allCaughtUp,
+                style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 8),
-              const Text(
-                'No sentences due for review right now.',
+              Text(
+                l10n.noSentencesDue,
                 textAlign: TextAlign.center,
-                style: TextStyle(color: Colors.grey),
+                style: const TextStyle(color: Colors.grey),
               ),
               const SizedBox(height: 20),
               ElevatedButton.icon(
                 onPressed: _loadSentences,
                 icon: const Icon(Icons.refresh),
-                label: const Text('Refresh'),
+                label: Text(l10n.refreshButton),
               ),
             ],
           ),
@@ -475,7 +478,7 @@ class _SentencesScreenState extends State<SentencesScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Sentence Review'),
+        title: Text(l10n.sentenceReviewTitle),
         actions: [
           // Sync options popup
           _syncing
@@ -518,7 +521,7 @@ class _SentencesScreenState extends State<SentencesScreen> {
                 ),
           // Stats
           IconButton(
-            tooltip: 'Stats & Streak',
+            tooltip: l10n.statsAndStreakTooltip,
             icon: const Icon(Icons.bar_chart_outlined),
             onPressed: () => Navigator.push(
               context,
@@ -529,7 +532,7 @@ class _SentencesScreenState extends State<SentencesScreen> {
             padding: const EdgeInsets.only(right: 16),
             child: Center(
               child: Text(
-                '$remaining left',
+                l10n.reviewRemaining(remaining),
                 style: const TextStyle(fontSize: 13, color: Colors.grey),
               ),
             ),
@@ -651,8 +654,8 @@ class _SentencesScreenState extends State<SentencesScreen> {
                                 Row(
                                   mainAxisSize: MainAxisSize.min,
                                   children: [
-                                    const Text(
-                                      'Audio unavailable',
+                                    Text(
+                                      l10n.audioUnavailable,
                                       style: TextStyle(fontSize: 11, color: Colors.grey),
                                     ),
                                     IconButton(
@@ -759,8 +762,8 @@ class _SentencesScreenState extends State<SentencesScreen> {
                               size: 16,
                             ),
                             label: Text(_showQA
-                                ? 'Hide Q&A'
-                                : 'Show Q&A (${qa.length} pairs)'),
+                                ? l10n.hideQa
+                                : l10n.showQa(qa.length)),
                           ),
                         ),
                         if (_showQA) ...[
@@ -932,25 +935,25 @@ class _SentencesScreenState extends State<SentencesScreen> {
             ),
             child: Column(
               children: [
-                const Text(
-                  'How well did you remember?',
+                Text(
+                  l10n.howWellDidYouRemember,
                   style: TextStyle(fontSize: 12, color: Colors.grey),
                 ),
                 const SizedBox(height: 8),
                 Row(
                   children: [
-                    _scoreButton('Again', 0, Colors.red),
-                    _scoreButton('Hard', 2, Colors.orange),
-                    _scoreButton('Good', 3, Colors.blue),
-                    _scoreButton('Easy', 5, Colors.green),
+                    _scoreButton(l10n.scoreAgain, 0, Colors.red),
+                    _scoreButton(l10n.scoreHard, 2, Colors.orange),
+                    _scoreButton(l10n.scoreGood, 3, Colors.blue),
+                    _scoreButton(l10n.scoreEasy, 5, Colors.green),
                   ],
                 ),
                 const SizedBox(height: 4),
                 TextButton(
                   onPressed: _scoring ? null : _next,
-                  child: const Text(
-                    'Skip',
-                    style: TextStyle(fontSize: 12, color: Colors.grey),
+                  child: Text(
+                    l10n.skipButton,
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
                   ),
                 ),
               ],

--- a/android_app/lib/screens/stats_screen.dart
+++ b/android_app/lib/screens/stats_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../services/local_db_service.dart';
+import '../l10n/app_localizations.dart';
 
 /// Review statistics and streak screen.
 class StatsScreen extends StatefulWidget {
@@ -14,11 +15,11 @@ class _StatsScreenState extends State<StatsScreen> {
   bool _loading = true;
   Map<String, dynamic> _stats = {};
 
-  static const _scoreLabels = {
-    0: ('Again', Colors.red),
-    2: ('Hard', Colors.orange),
-    3: ('Good', Colors.blue),
-    5: ('Easy', Colors.green),
+  static const _scoreColors = {
+    0: Colors.red,
+    2: Colors.orange,
+    3: Colors.blue,
+    5: Colors.green,
   };
 
   @override
@@ -35,14 +36,15 @@ class _StatsScreenState extends State<StatsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Stats & Streak'),
+        title: Text(l10n.statsTitle),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: _load,
-            tooltip: 'Refresh',
+            tooltip: l10n.refreshTooltip,
           ),
         ],
       ),
@@ -64,7 +66,15 @@ class _StatsScreenState extends State<StatsScreen> {
     );
   }
 
+  Map<int, String> _localScoreLabels(AppLocalizations l10n) => {
+    0: l10n.scoreAgain,
+    2: l10n.scoreHard,
+    3: l10n.scoreGood,
+    5: l10n.scoreEasy,
+  };
+
   Widget _buildStreakCard() {
+    final l10n = AppLocalizations.of(context);
     final streak = _stats['streak'] as int? ?? 0;
     final today = _stats['today'] as int? ?? 0;
     return Card(
@@ -79,14 +89,14 @@ class _StatsScreenState extends State<StatsScreen> {
             ),
             const SizedBox(height: 4),
             Text(
-              streak == 1 ? 'day streak' : 'day streak',
+              l10n.dayStreak,
               style: TextStyle(fontSize: 16, color: Colors.grey.shade600),
             ),
             if (today > 0) ...[
               const SizedBox(height: 12),
               Chip(
                 label: Text(
-                  '✓ $today reviewed today',
+                  l10n.reviewedToday(today),
                   style: const TextStyle(fontSize: 12),
                 ),
                 backgroundColor: Colors.green.shade100,
@@ -94,9 +104,9 @@ class _StatsScreenState extends State<StatsScreen> {
             ] else ...[
               const SizedBox(height: 12),
               Chip(
-                label: const Text(
-                  'No reviews yet today',
-                  style: TextStyle(fontSize: 12),
+                label: Text(
+                  l10n.noReviewsToday,
+                  style: const TextStyle(fontSize: 12),
                 ),
                 backgroundColor: Colors.grey.shade100,
               ),
@@ -108,6 +118,7 @@ class _StatsScreenState extends State<StatsScreen> {
   }
 
   Widget _buildSummaryCard() {
+    final l10n = AppLocalizations.of(context);
     final total = _stats['total'] as int? ?? 0;
     final today = _stats['today'] as int? ?? 0;
     return Card(
@@ -116,13 +127,13 @@ class _StatsScreenState extends State<StatsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Overview',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            Text(
+              l10n.statsOverview,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 12),
-            _statRow('Total reviews', '$total'),
-            _statRow('Reviewed today', '$today'),
+            _statRow(l10n.statsTotalReviews, '$total'),
+            _statRow(l10n.statsReviewedTodayLabel, '$today'),
           ],
         ),
       ),
@@ -146,13 +157,14 @@ class _StatsScreenState extends State<StatsScreen> {
   }
 
   Widget _buildDistributionCard() {
+    final l10n = AppLocalizations.of(context);
     final dist = (_stats['distribution'] as Map<int, int>?) ?? {};
     final total = dist.values.fold<int>(0, (a, b) => a + b);
     if (total == 0) {
-      return const Card(
+      return Card(
         child: Padding(
-          padding: EdgeInsets.all(16),
-          child: Text('No scores recorded yet.'),
+          padding: const EdgeInsets.all(16),
+          child: Text(l10n.statsNoScores),
         ),
       );
     }
@@ -163,14 +175,15 @@ class _StatsScreenState extends State<StatsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Score distribution',
+            Text(
+              l10n.statsScoreDistribution,
               style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 12),
-            ..._scoreLabels.entries.map((entry) {
+            ..._scoreColors.entries.map((entry) {
               final score = entry.key;
-              final (label, color) = entry.value;
+              final color = entry.value;
+              final label = _localScoreLabels(l10n)[score] ?? '$score';
               final count = dist[score] ?? 0;
               final fraction = total > 0 ? count / total : 0.0;
               return Padding(

--- a/android_app/lib/services/api_service.dart
+++ b/android_app/lib/services/api_service.dart
@@ -174,6 +174,24 @@ class ApiService {
     return jsonDecode(resp.body) as Map<String, dynamic>;
   }
 
+  /// Fetch the complete Day object for a given date (all variants, all entries, title, etc.).
+  /// [date] in YYYY-MM-DD or YYYY/MM/DD format.
+  static Future<Map<String, dynamic>> getDayData(String date) async {
+    final base = await _baseUrl();
+    final headers = await _authHeaders();
+    final dateFmt = date.replaceAll('/', '-');
+    final resp = await http
+        .get(
+          Uri.parse('$base/api/diary/day/$dateFmt'),
+          headers: headers,
+        )
+        .timeout(_timeout);
+    if (resp.statusCode != 200) {
+      throw ApiException(resp.statusCode, 'Failed to get day data');
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
+
   /// Score an individual entry via SM-2.
   /// [score]: 0=Again, 2=Hard, 3=Good, 5=Easy
   static Future<Map<String, dynamic>> scoreEntry(

--- a/android_app/lib/services/db_mobile.dart
+++ b/android_app/lib/services/db_mobile.dart
@@ -14,14 +14,18 @@ class LocalDbService {
     final path = join(await getDatabasesPath(), 'lingodiary.db');
     return openDatabase(
       path,
-      version: 2,
+      version: 3,
       onCreate: (db, version) async {
         await _createV1Tables(db);
         await _createV2Tables(db);
+        await _createV3Tables(db);
       },
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
           await _createV2Tables(db);
+        }
+        if (oldVersion < 3) {
+          await _createV3Tables(db);
         }
       },
     );
@@ -69,6 +73,16 @@ class LocalDbService {
         date TEXT PRIMARY KEY,
         last_reviewed TEXT NOT NULL,
         synced INTEGER NOT NULL DEFAULT 0
+      )
+    ''');
+  }
+
+  static Future<void> _createV3Tables(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS day_cache (
+        date TEXT PRIMARY KEY,
+        day_json TEXT NOT NULL,
+        fetched_at TEXT NOT NULL
       )
     ''');
   }
@@ -150,6 +164,38 @@ class LocalDbService {
   static Future<List<Map<String, dynamic>>> getLessons() async {
     final database = await db;
     return database.query('lessons_cache', orderBy: 'display DESC');
+  }
+
+  // ---- Day cache ----
+
+  static Future<void> saveDayCache(String date, Map<String, dynamic> dayObject) async {
+    final database = await db;
+    await database.insert(
+      'day_cache',
+      {
+        'date': date,
+        'day_json': jsonEncode(dayObject),
+        'fetched_at': DateTime.now().toIso8601String(),
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  static Future<Map<String, dynamic>?> getDayCache(String date) async {
+    final database = await db;
+    final rows = await database.query('day_cache', where: 'date = ?', whereArgs: [date]);
+    if (rows.isEmpty) return null;
+    try {
+      return jsonDecode(rows.first['day_json'] as String) as Map<String, dynamic>;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<List<String>> getAllCachedDates() async {
+    final database = await db;
+    final rows = await database.query('day_cache', columns: ['date']);
+    return rows.map((r) => r['date'] as String).toList();
   }
 
   // ---- Home cache ----
@@ -295,6 +341,7 @@ class LocalDbService {
     await database.delete('home_cache');
     await database.delete('srs_scores');
     await database.delete('lesson_last_reviewed');
+    await database.delete('day_cache');
   }
 
   // ---- Lesson last_reviewed tracking ----

--- a/android_app/lib/services/db_stub.dart
+++ b/android_app/lib/services/db_stub.dart
@@ -103,4 +103,12 @@ class LocalDbService {
   static Future<void> markLessonReviewSynced(String date) async {}
 
   static Future<List<Map<String, dynamic>>> getRecentlyStudiedLessons({int limit = 10}) async => [];
+
+  // ---- Day cache (no-op on stub) ----
+
+  static Future<void> saveDayCache(String date, Map<String, dynamic> dayObject) async {}
+
+  static Future<Map<String, dynamic>?> getDayCache(String date) async => null;
+
+  static Future<List<String>> getAllCachedDates() async => [];
 }

--- a/android_app/lib/services/db_web.dart
+++ b/android_app/lib/services/db_web.dart
@@ -131,4 +131,12 @@ class LocalDbService {
   static Future<void> markLessonReviewSynced(String date) async {}
 
   static Future<List<Map<String, dynamic>>> getRecentlyStudiedLessons({int limit = 10}) async => [];
+
+  // ---- Day cache (no-op on web — always reads from API) ----
+
+  static Future<void> saveDayCache(String date, Map<String, dynamic> dayObject) async {}
+
+  static Future<Map<String, dynamic>?> getDayCache(String date) async => null;
+
+  static Future<List<String>> getAllCachedDates() async => [];
 }

--- a/android_app/lib/services/sync_manager.dart
+++ b/android_app/lib/services/sync_manager.dart
@@ -96,7 +96,7 @@ class SyncManager extends ChangeNotifier {
     }
   }
 
-  Future<void> syncLesson(String base) async {
+  Future<void> syncLesson(String base, {String? date}) async {
     if (isSyncing) return;
     _start('Loading manifest…');
     try {
@@ -118,6 +118,16 @@ class SyncManager extends ChangeNotifier {
       message = _cancelled ? 'Cancelled.' : 'Synced $count file(s) ✓';
       progress = 1.0;
       notifyListeners();
+
+      // After successful sync, populate day_cache if date is known
+      if (date != null && !_cancelled) {
+        try {
+          final dayData = await ApiService.getDayData(date);
+          await LocalDbService.saveDayCache(date, dayData);
+        } catch (_) {
+          // Non-fatal — lesson text will be loaded on next player open
+        }
+      }
     } catch (e) {
       message = 'Sync failed: $e';
       progress = null;
@@ -155,6 +165,28 @@ class SyncManager extends ChangeNotifier {
         message = _cancelled ? 'Cancelled.' : 'Synced $count file(s) ✓';
         progress = 1.0;
         notifyListeners();
+
+        // After successful sync, populate day_cache for all lessons
+        if (!_cancelled) {
+          try {
+            message = 'Caching lesson text…';
+            notifyListeners();
+            final lessons = await ApiService.getLessons();
+            for (final lesson in lessons) {
+              if (_cancelled) break;
+              final date = lesson['date'] as String?;
+              if (date == null || date.isEmpty) continue;
+              try {
+                final dayData = await ApiService.getDayData(date);
+                await LocalDbService.saveDayCache(date, dayData);
+              } catch (_) {
+                // Non-fatal — skip this day
+              }
+            }
+          } catch (_) {
+            // Non-fatal — text cache population failed, will retry on lesson open
+          }
+        }
       }
     } catch (e) {
       message = 'Sync failed: $e';

--- a/android_app/lib/widgets/connection_badge.dart
+++ b/android_app/lib/widgets/connection_badge.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../l10n/app_localizations.dart';
 import '../services/sync_manager.dart';
 
 class ConnectionBadge extends StatelessWidget {
@@ -9,6 +10,7 @@ class ConnectionBadge extends StatelessWidget {
     return ListenableBuilder(
       listenable: SyncManager.instance,
       builder: (context, _) {
+        final l10n = AppLocalizations.of(context);
         final online = SyncManager.instance.isOnline;
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),
@@ -22,7 +24,7 @@ class ConnectionBadge extends StatelessWidget {
               ),
               const SizedBox(width: 4),
               Text(
-                online ? 'Server online' : 'Server offline',
+                online ? l10n.serverOnline : l10n.serverOffline,
                 style: TextStyle(
                   fontSize: 12,
                   color: online ? Colors.green : Colors.red,

--- a/docs/adr/0002-lesson-text-sync-via-sqlite.md
+++ b/docs/adr/0002-lesson-text-sync-via-sqlite.md
@@ -1,0 +1,34 @@
+# Lesson text synced into SQLite per-day, not via diary.json download
+
+`diary.json` is the server's single source of truth for all lesson content. Before this decision, the Android app always bundled `diary.json` in every per-lesson sync manifest, meaning syncing a single lesson downloaded the entire file — already 10 MB at 69 days and growing ~150 KB/day.
+
+We decided that the Android app will never download `diary.json` at all. Instead:
+
+1. A new server endpoint `GET /api/diary/day/{date}` returns the **complete Day object** for one date — all 4 Lesson Variants, all entries including `title`, `tips`, `user_trial_translation`, reviewing state, and audio timings. Median size is ~85 KB per day.
+2. The Android app caches this response in a `day_cache` SQLite table (primary key: `date`). One row per Day.
+3. Per-lesson sync and Sync All populate `day_cache` by calling this endpoint for each affected day.
+4. The player reads text offline from `day_cache`. When online, it refreshes the cache in the background on every lesson open — ensuring scores made on another device are reflected next time the lesson is opened.
+5. `diary.json` is removed from all sync manifests.
+
+The `day_cache` schema:
+```sql
+CREATE TABLE day_cache (
+  date       TEXT PRIMARY KEY,  -- YYYY-MM-DD
+  day_json   TEXT NOT NULL,     -- complete Day object from /api/diary/day/{date}
+  fetched_at TEXT NOT NULL
+)
+```
+
+## Considered options
+
+- **Per-day JSON files on disk** (`diary/YYYY-MM-DD.json` referenced from the manifest) — rejected because it adds server-side file management and still requires manifest coordination.
+- **Per-variant endpoint `getLessonEntries`** (4 calls per day) — rejected in favour of a single full-day endpoint that includes all fields and all variants at once.
+- **Keep diary.json in Sync All only** — rejected because it still means re-downloading 10 MB+ on every full sync.
+- **No local cache; always fetch live from API** — rejected because offline text during lesson playback is a hard requirement.
+
+## Consequences
+
+- `day_cache` must be populated before a lesson can be played offline. This happens automatically during `syncLesson()` or `syncAll()` (both require connectivity).
+- Reviewing state inside the cached JSON is a snapshot. It is refreshed on the next lesson open when online. Scores submitted offline are queued in `srs_scores` and flushed when connectivity is restored — the server remains authoritative for SM-2 computation.
+- Cross-device reviewing state (e.g. scored on a computer, then opened on phone) is visible on the phone the next time the lesson is opened while online. Real-time push is not needed.
+- The web browser version is unaffected — it always reads live from the API and has no local file cache.

--- a/lingodiary/audio_timing.py
+++ b/lingodiary/audio_timing.py
@@ -490,7 +490,7 @@ def backfill_audio_timings(
         f"repeat={repeat_tprs}, pause={pause_ms}ms, silence={answer_silence_ms}ms"
     )
 
-    tts_plugin = PiperTTSPlugin(lang=lang, config={"lang": lang, "voice": voice})
+    tts_plugin = PiperTTSPlugin({"lang": lang, "voice": voice})
     tts_plugin.length_scale = length_scale
 
     diary = load_diary_json(diary_json_path)

--- a/lingodiary/audio_timing.py
+++ b/lingodiary/audio_timing.py
@@ -212,61 +212,6 @@ def _assemble_full_mp3(
     return True
 
 
-def _mp3_stale(day, variant_key: str) -> bool:
-    """Return True if the full lesson MP3 is stale relative to its Q&A segments.
-
-    Checks both sentence_audio_generated_at and qa.generated_at against the
-    stored lesson_mp3_timestamps[variant_key].  Any segment newer than the
-    full MP3 — or missing a timestamp — triggers a rebuild.
-    """
-    mp3_ts_str = day.lesson_mp3_timestamps.get(variant_key)
-    if mp3_ts_str is None:
-        # No MP3 timestamp — can't evaluate; let segments_newly_generated handle it
-        return False
-
-    try:
-        mp3_ts = datetime.fromisoformat(mp3_ts_str)
-    except (ValueError, TypeError):
-        logger.warning(
-            f"  Malformed lesson_mp3_timestamps[{variant_key!r}]={mp3_ts_str!r} "
-            f"for {day.date} — treating MP3 as stale."
-        )
-        return True
-
-    for entry in day.entries:
-        v = entry.lessons.get_variant(variant_key)
-
-        # Check sentence segment
-        if v.sentence_audio_path:
-            if v.sentence_audio_generated_at is None:
-                return True
-            try:
-                if datetime.fromisoformat(v.sentence_audio_generated_at) > mp3_ts:
-                    return True
-            except (ValueError, TypeError):
-                logger.warning(
-                    f"  Malformed sentence_audio_generated_at on entry "
-                    f"{entry.index} ({day.date}) — treating as stale."
-                )
-                return True
-
-        # Check Q&A segments
-        for qa in v.qa:
-            if qa.generated_at is None:
-                return True
-            try:
-                if datetime.fromisoformat(qa.generated_at) > mp3_ts:
-                    return True
-            except (ValueError, TypeError):
-                logger.warning(
-                    f"  Malformed qa.generated_at on entry {entry.index} "
-                    f"({day.date}) — treating as stale."
-                )
-                return True
-
-    return False
-
-
 def _compute_day_timings(
     entries: list,
     variant_key: str,
@@ -442,27 +387,206 @@ def _recompute_timings_from_segments(
     return timings
 
 
+def _process_day_audio(
+    day,
+    variants: list[str],
+    tts_plugin,
+    lang: str,
+    voice: str,
+    repeat_tprs: int,
+    pause_ms: int,
+    answer_silence_ms: int,
+    output_dir: str,
+    tprs_dir: str,
+    overwrite_existing: bool = False,
+) -> bool:
+    """Generate segments, compute timings, and assemble the full MP3 for one DiaryDay.
+
+    Returns True if the day object was modified (caller should save diary.json).
+    """
+    from lingodiary.diary_json import AudioTiming  # type: ignore
+
+    day_modified = False
+
+    # Fill lesson_audio_paths from existing MP3 files on disk
+    for variant_key in variants:
+        suffix = _KEY_TO_SUFFIX.get(variant_key, "")
+        mp3_path = _find_day_mp3(tprs_dir, day.date, suffix)
+        if mp3_path and variant_key not in day.lesson_audio_paths:
+            day.lesson_audio_paths[variant_key] = os.path.relpath(mp3_path, output_dir)
+            day_modified = True
+
+    for variant_key in variants:
+        populated = [
+            e for e in day.entries if e.lessons.get_variant(variant_key).sentence
+        ]
+        if not populated:
+            logger.debug(f"  {variant_key}: no entries, skipping.")
+            continue
+
+        segs_dir = _segments_dir(output_dir, day.date, variant_key)
+
+        segments_newly_generated = False
+        if not overwrite_existing and _segments_complete(
+            segs_dir, day.entries, variant_key
+        ):
+            logger.info(f"  {variant_key}: segments already complete, skipping TTS.")
+
+            # Backfill audio paths and generated_at timestamps from segment files
+            for idx, entry in enumerate(day.entries):
+                v = entry.lessons.get_variant(variant_key)
+                if not v.sentence:
+                    continue
+                s_path = os.path.join(segs_dir, f"{idx}_s.mp3")
+                if os.path.exists(s_path):
+                    if v.sentence_audio_path == "":
+                        v.sentence_audio_path = os.path.relpath(s_path, output_dir)
+                        day_modified = True
+                    if v.sentence_audio_generated_at is None:
+                        mtime = os.path.getmtime(s_path)
+                        v.sentence_audio_generated_at = datetime.fromtimestamp(
+                            mtime, tz=timezone.utc
+                        ).isoformat()
+                        day_modified = True
+
+                for j, qa in enumerate(v.qa):
+                    q_path = os.path.join(segs_dir, f"{idx}_q{j}.mp3")
+                    a_path = os.path.join(segs_dir, f"{idx}_a{j}.mp3")
+                    if qa.question_audio_path == "" and os.path.exists(q_path):
+                        qa.question_audio_path = os.path.relpath(q_path, output_dir)
+                        day_modified = True
+                    if qa.answer_audio_path == "" and os.path.exists(a_path):
+                        qa.answer_audio_path = os.path.relpath(a_path, output_dir)
+                        day_modified = True
+                    if qa.generated_at is None and os.path.exists(q_path):
+                        mtime = max(
+                            os.path.getmtime(q_path),
+                            os.path.getmtime(a_path) if os.path.exists(a_path) else 0,
+                        )
+                        qa.generated_at = datetime.fromtimestamp(
+                            mtime, tz=timezone.utc
+                        ).isoformat()
+                        day_modified = True
+
+            # Recompute timing from segment files if any entry has zero end_ms
+            needs_timing = any(
+                entry.lessons.get_variant(variant_key).sentence
+                and entry.lessons.get_variant(variant_key).audio_timing.end_ms == 0
+                for entry in day.entries
+            )
+            if needs_timing:
+                logger.info(
+                    f"  {variant_key}: zero timing detected — recomputing from segments."
+                )
+                fixed_timings = _recompute_timings_from_segments(
+                    day.entries,
+                    variant_key,
+                    segs_dir,
+                    repeat_tprs,
+                    pause_ms,
+                    answer_silence_ms,
+                    output_dir,
+                )
+                if fixed_timings:
+                    for entry, (start_ms, end_ms) in zip(day.entries, fixed_timings):
+                        v = entry.lessons.get_variant(variant_key)
+                        if v.sentence:
+                            v.audio_timing = AudioTiming(
+                                start_ms=start_ms, end_ms=end_ms
+                            )
+                            day_modified = True
+                    logger.info(
+                        f"  {variant_key}: timing fixed. Last end_ms={fixed_timings[-1][1]}ms "
+                        f"(~{fixed_timings[-1][1]//1000}s)"
+                    )
+        else:
+            logger.info(
+                f"  {variant_key}: generating segments for {len(populated)} entries "
+                f"(repeat x{repeat_tprs})..."
+            )
+            timings = _compute_day_timings(
+                day.entries,
+                variant_key,
+                tts_plugin,
+                lang,
+                voice,
+                repeat_tprs,
+                pause_ms,
+                answer_silence_ms,
+                output_dir=output_dir,
+                date_str=day.date,
+            )
+            if not timings:
+                continue
+
+            for entry, (start_ms, end_ms) in zip(day.entries, timings):
+                v = entry.lessons.get_variant(variant_key)
+                if v.sentence:
+                    v.audio_timing = AudioTiming(start_ms=start_ms, end_ms=end_ms)
+                    day_modified = True
+
+            logger.info(
+                f"  {variant_key}: done. Last end_ms={timings[-1][1]}ms "
+                f"(~{timings[-1][1]//1000}s)"
+            )
+            segments_newly_generated = True
+
+        # Rebuild the full MP3 when: segments are new OR the file is missing
+        mp3_rel = day.lesson_audio_paths.get(variant_key, "")
+        if not mp3_rel and segments_newly_generated:
+            date_dash = day.date.replace("/", "-")
+            suffix = _KEY_TO_SUFFIX.get(variant_key, "")
+            fname = f"TPRS_{date_dash}{suffix}.mp3"
+            mp3_rel = os.path.join("TPRS", fname)
+            day.lesson_audio_paths[variant_key] = mp3_rel
+            day_modified = True
+            logger.info(
+                f"  {variant_key}: no existing MP3 path — will write to {mp3_rel}"
+            )
+        mp3_path = os.path.join(output_dir, mp3_rel) if mp3_rel else None
+        if mp3_path and (segments_newly_generated or not os.path.exists(mp3_path)):
+            rebuilt = _assemble_full_mp3(
+                day.entries,
+                variant_key,
+                segs_dir,
+                repeat_tprs,
+                pause_ms,
+                answer_silence_ms,
+                mp3_path,
+            )
+            if rebuilt:
+                day_modified = True
+                day.lesson_mp3_timestamps[variant_key] = datetime.now(
+                    timezone.utc
+                ).isoformat()
+                logger.info(f"  {variant_key}: rebuilt MP3 at {mp3_path}.")
+        else:
+            logger.debug(f"  {variant_key}: MP3 up-to-date, skipping rebuild.")
+
+    return day_modified
+
+
 def backfill_audio_timings(
     config_path: str | Path,
     diary_json_path: str | Path,
     variants: list[str] | None = None,
     overwrite_existing: bool = False,
 ) -> None:
-    """
-    Generate individual segment MP3s and store per-sentence audio timings for
-    all TPRS variant lessons.
+    """Generate/repair segment MP3s, timings, and full Lesson Audio for all Days.
+
+    Loops over every DiaryDay in diary.json and calls _process_day_audio for each.
+    Saves diary.json after each modified day so progress survives interruptions.
 
     Args:
         config_path:         Path to the user's config.yaml.
-        diary_json_path:     Path to diary.json (updated in-place, saved per day).
+        diary_json_path:     Path to diary.json (updated in-place).
         variants:            Variant keys to process. Defaults to all four.
-        overwrite_existing:  If False (default), skip days where segment files
-                             are already complete.
+        overwrite_existing:  If True, regenerate segments even when already present.
     """
     import yaml  # type: ignore
     from ovos_tts_plugin_piper import PiperTTSPlugin  # type: ignore
 
-    from lingodiary.diary_json import AudioTiming, load_diary_json, save_diary_json
+    from lingodiary.diary_json import load_diary_json, save_diary_json
 
     variants = variants or list(_VARIANT_KEYS)
     diary_json_path = Path(diary_json_path)
@@ -500,173 +624,19 @@ def backfill_audio_timings(
     try:
         for day_idx, day in enumerate(diary.diaries, 1):
             logger.info(f"Day {day_idx}/{total_days}: {day.date} -- {day.title}")
-            day_modified = False
-
-            # Fill lesson_audio_paths for this day
-            for variant_key in variants:
-                suffix = _KEY_TO_SUFFIX.get(variant_key, "")
-                mp3_path = _find_day_mp3(tprs_dir, day.date, suffix)
-                if mp3_path and variant_key not in day.lesson_audio_paths:
-                    day.lesson_audio_paths[variant_key] = os.path.relpath(
-                        mp3_path, output_dir
-                    )
-                    day_modified = True
-
-            for variant_key in variants:
-                populated = [
-                    e
-                    for e in day.entries
-                    if e.lessons.get_variant(variant_key).sentence
-                ]
-                if not populated:
-                    logger.debug(f"  {variant_key}: no entries, skipping.")
-                    continue
-
-                segs_dir = _segments_dir(output_dir, day.date, variant_key)
-
-                segments_newly_generated = False
-                if not overwrite_existing and _segments_complete(
-                    segs_dir, day.entries, variant_key
-                ):
-                    logger.info(
-                        f"  {variant_key}: segments already complete, skipping TTS."
-                    )
-                    # Fill paths if they're missing from the JSON
-                    for idx, entry in enumerate(day.entries):
-                        v = entry.lessons.get_variant(variant_key)
-                        if not v.sentence:
-                            continue
-                        s_path = os.path.join(segs_dir, f"{idx}_s.mp3")
-                        if v.sentence_audio_path == "" and os.path.exists(s_path):
-                            v.sentence_audio_path = os.path.relpath(s_path, output_dir)
-                            day_modified = True
-                        for j, qa in enumerate(v.qa):
-                            q_path = os.path.join(segs_dir, f"{idx}_q{j}.mp3")
-                            a_path = os.path.join(segs_dir, f"{idx}_a{j}.mp3")
-                            if qa.question_audio_path == "" and os.path.exists(q_path):
-                                qa.question_audio_path = os.path.relpath(
-                                    q_path, output_dir
-                                )
-                                day_modified = True
-                            if qa.answer_audio_path == "" and os.path.exists(a_path):
-                                qa.answer_audio_path = os.path.relpath(
-                                    a_path, output_dir
-                                )
-                                day_modified = True
-
-                    # Recompute timing from segment files if any entry has zero end_ms.
-                    # This fixes days where TTS was generated successfully but the
-                    # sentence-level audio_timing was stored as {start_ms:0, end_ms:0}.
-                    needs_timing = any(
-                        entry.lessons.get_variant(variant_key).sentence
-                        and entry.lessons.get_variant(variant_key).audio_timing.end_ms
-                        == 0
-                        for entry in day.entries
-                    )
-                    if needs_timing:
-                        logger.info(
-                            f"  {variant_key}: zero timing detected — recomputing from segments."
-                        )
-                        fixed_timings = _recompute_timings_from_segments(
-                            day.entries,
-                            variant_key,
-                            segs_dir,
-                            repeat_tprs,
-                            pause_ms,
-                            answer_silence_ms,
-                            output_dir,
-                        )
-                        if fixed_timings:
-                            for entry, (start_ms, end_ms) in zip(
-                                day.entries, fixed_timings
-                            ):
-                                v = entry.lessons.get_variant(variant_key)
-                                if v.sentence:
-                                    v.audio_timing = AudioTiming(
-                                        start_ms=start_ms, end_ms=end_ms
-                                    )
-                                    day_modified = True
-                            logger.info(
-                                f"  {variant_key}: timing fixed. Last end_ms={fixed_timings[-1][1]}ms "
-                                f"(~{fixed_timings[-1][1]//1000}s)"
-                            )
-                else:
-                    logger.info(
-                        f"  {variant_key}: generating segments for {len(populated)} entries "
-                        f"(repeat x{repeat_tprs})..."
-                    )
-                    timings = _compute_day_timings(
-                        day.entries,
-                        variant_key,
-                        tts_plugin,
-                        lang,
-                        voice,
-                        repeat_tprs,
-                        pause_ms,
-                        answer_silence_ms,
-                        output_dir=output_dir,
-                        date_str=day.date,
-                    )
-                    if not timings:
-                        continue
-
-                    for entry, (start_ms, end_ms) in zip(day.entries, timings):
-                        v = entry.lessons.get_variant(variant_key)
-                        if v.sentence:
-                            v.audio_timing = AudioTiming(
-                                start_ms=start_ms, end_ms=end_ms
-                            )
-                            day_modified = True
-
-                    logger.info(
-                        f"  {variant_key}: done. Last end_ms={timings[-1][1]}ms "
-                        f"(~{timings[-1][1]//1000}s)"
-                    )
-                    segments_newly_generated = True
-
-                # Rebuild the full MP3 from segment files only when needed:
-                # - segments were newly generated (timing must stay in sync), OR
-                # - the MP3 file is missing (segments exist but the MP3 was lost), OR
-                # - Q&A segments are newer than the full MP3 (stale MP3 detection)
-                mp3_rel = day.lesson_audio_paths.get(variant_key, "")
-                if not mp3_rel and segments_newly_generated:
-                    # No prior full MP3 (e.g. standalone backfill run with no prior
-                    # convert_to_audio()).  Compute a sensible default path so the
-                    # segments we just generated are actually assembled.
-                    date_dash = day.date.replace("/", "-")
-                    suffix = _KEY_TO_SUFFIX.get(variant_key, "")
-                    fname = f"TPRS_{date_dash}{suffix}.mp3"
-                    mp3_rel = os.path.join("TPRS", fname)
-                    day.lesson_audio_paths[variant_key] = mp3_rel
-                    day_modified = True
-                    logger.info(
-                        f"  {variant_key}: no existing MP3 path — will write to {mp3_rel}"
-                    )
-                mp3_path = os.path.join(output_dir, mp3_rel) if mp3_rel else None
-                if mp3_path and (
-                    segments_newly_generated
-                    or not os.path.exists(mp3_path)
-                    or _mp3_stale(day, variant_key)
-                ):
-                    rebuilt = _assemble_full_mp3(
-                        day.entries,
-                        variant_key,
-                        segs_dir,
-                        repeat_tprs,
-                        pause_ms,
-                        answer_silence_ms,
-                        mp3_path,
-                    )
-                    if rebuilt:
-                        day_modified = True
-                        day.lesson_mp3_timestamps[variant_key] = datetime.now(
-                            timezone.utc
-                        ).isoformat()
-                        logger.info(f"  {variant_key}: rebuilt MP3 at {mp3_path}.")
-                else:
-                    logger.debug(f"  {variant_key}: MP3 up-to-date, skipping rebuild.")
-
-            # Save after each day so progress is not lost on interruption
+            day_modified = _process_day_audio(
+                day=day,
+                variants=variants,
+                tts_plugin=tts_plugin,
+                lang=lang,
+                voice=voice,
+                repeat_tprs=repeat_tprs,
+                pause_ms=pause_ms,
+                answer_silence_ms=answer_silence_ms,
+                output_dir=output_dir,
+                tprs_dir=tprs_dir,
+                overwrite_existing=overwrite_existing,
+            )
             if day_modified:
                 save_diary_json(diary, diary_json_path)
                 logger.info(f"  Saved progress for {day.date}.")

--- a/lingodiary/audio_timing.py
+++ b/lingodiary/audio_timing.py
@@ -490,7 +490,7 @@ def backfill_audio_timings(
         f"repeat={repeat_tprs}, pause={pause_ms}ms, silence={answer_silence_ms}ms"
     )
 
-    tts_plugin = PiperTTSPlugin()
+    tts_plugin = PiperTTSPlugin(lang=lang, config={"lang": lang, "voice": voice})
     tts_plugin.length_scale = length_scale
 
     diary = load_diary_json(diary_json_path)

--- a/lingodiary/diary.py
+++ b/lingodiary/diary.py
@@ -67,8 +67,6 @@ import hashlib
 import json
 import logging
 import os
-import re
-import tempfile
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -78,11 +76,7 @@ from typing import Callable
 
 import yaml
 from openai import OpenAI
-from ovos_plugin_manager.tts import load_tts_plugin
-from ovos_tts_plugin_piper import PiperTTSPlugin
-from piper import PiperVoice
 from platformdirs import user_config_dir
-from pydub import AudioSegment
 
 from lingodiary.diary_json import (
     AudioTiming,
@@ -839,297 +833,6 @@ class TprsVariantHandler:
             self.logging.warning(
                 f"Could not write {self.variant_name} TPRS data to JSON diary: {exc}"
             )
-
-    def _record_lesson_audio_path(self, date_str: str, audio_filepath: str):
-        """Record the generated lesson audio path in diary.json."""
-        json_path = self.config.get("json_diary_path")
-        if not json_path:
-            return
-        try:
-            diary_db = load_diary_json(json_path)
-            day = get_day(diary_db, date_str)
-            if day is None:
-                return
-            # Store path relative to output_dir for portability
-            output_dir = self.config.get("output_dir", "")
-            rel_path = (
-                os.path.relpath(audio_filepath, output_dir)
-                if output_dir
-                else audio_filepath
-            )
-            # Use the same key convention as audio_timing.py so both systems
-            # write to / read from the same entry in lesson_audio_paths.
-            variant_key = VARIANT_AUDIO_KEY_MAP.get(
-                self.variant_name, self.variant_name.lower()
-            )
-            day.lesson_audio_paths[variant_key] = rel_path
-            save_diary_json(diary_db, json_path)
-        except Exception as exc:
-            self.logging.warning(
-                f"Could not record lesson audio path in diary.json: {exc}"
-            )
-
-    def _create_audio_for_day_block(self, day_block_data, date_str):
-        """Generates a TPRS audio lesson for a given day's content for this variant."""
-        if (
-            not hasattr(self.tprs_creator, "titles_diary_dict")
-            or not self.tprs_creator.titles_diary_dict
-        ):
-            self.tprs_creator.get_all_diary_titles()
-
-        current_titles_dict = self.tprs_creator.titles_diary_dict
-        try:
-            title_date_obj = datetime.strptime(date_str, "%Y/%m/%d")
-        except ValueError:
-            self.logging.error(
-                f"Invalid date string format '{date_str}' for TPRS audio generation. Skipping."
-            )
-            return
-
-        title = current_titles_dict.get(
-            title_date_obj,
-            self.tprs_creator.titles_dict.get(title_date_obj, "No Title"),
-        )
-
-        if not title or title == "No Title":
-            self.logging.warning(
-                f"Skipping audio for {self.variant_name} on {date_str} due to missing/default title."
-            )
-            return
-
-        base_filename = f"{self.config['tprs_lesson_name']}_TPRS_{date_str.replace('/', '-')}_{title}{self.file_suffix}.mp3"
-        # Sanitize filename
-        base_filename = re.sub(r'[\\/*?:"<>|]', "", base_filename)
-        tprs_audio_lesson_filepath = os.path.join(
-            self.config["output_dir"], "TPRS", base_filename
-        )
-
-        os.makedirs(os.path.dirname(tprs_audio_lesson_filepath), exist_ok=True)
-
-        # If the file already exists on disk and overwrite is disabled, skip and
-        # backfill lesson_audio_paths so future runs don't even reach this point.
-        if os.path.exists(tprs_audio_lesson_filepath) and not self.config.get(
-            "overwrite_tprs_audio", False
-        ):
-            self.logging.info(
-                f"{self.variant_name} TPRS audio already on disk for {date_str} — skipping."
-            )
-            self._record_lesson_audio_path(date_str, tprs_audio_lesson_filepath)
-            return
-
-        self.logging.info(
-            f"Generating {self.variant_name} TPRS audio file for {date_str}: {tprs_audio_lesson_filepath}"
-        )
-
-        tts_plugin_instance = PiperTTSPlugin(
-            {
-                "lang": self.config["languages"]["study_language_code"],
-                "voice": self.config["tts"]["piper"]["voice"],
-            }
-        )
-        tts_plugin_instance.length_scale = self.config["tts"]["piper"][
-            "piper_length_scale_tprs"
-        ]
-
-        pause_filename = os.path.join(
-            tempfile.gettempdir(),
-            f"{self.tprs_creator.generate_unique_id('pause', 5)}.wav",
-        )
-        paused_duration = self.config["tts"]["pause_between_sentences_duration"]
-        repeat_tprs = (
-            self.config["tts"]["repeat_sentence_tprs"]
-            if self.config["tts"]["repeat_sentence_tprs"] > 0
-            else 1
-        )
-
-        # Ensure pause duration is not negative if repeat_tprs is large
-        actual_pause_duration = max(0, paused_duration / repeat_tprs)
-        pause_segment = AudioSegment.silent(duration=actual_pause_duration)
-        pause_segment.export(pause_filename, format="wav")
-
-        media_files = []
-        temp_files_to_clean = {pause_filename}  # Keep track of all temp files
-
-        total_sentences = len(day_block_data)
-        total_qa_pairs = sum(len(qa) for qa in day_block_data.values())
-        total_tts_calls = total_sentences + total_qa_pairs * 2
-        self.logging.info(
-            f"[TTS] {self.variant_name} {date_str}: {total_sentences} sentences, "
-            f"{total_qa_pairs} Q&A pairs → {total_tts_calls} TTS calls total"
-        )
-
-        try:
-            for sent_idx, (sentence, tprs_qa_list) in enumerate(
-                day_block_data.items(), 1
-            ):
-                self.logging.info(
-                    f"[TTS] {self.variant_name} sentence {sent_idx}/{total_sentences}: {sentence[:60]}"
-                )
-                t0 = time.time()
-                audio_filename = os.path.join(
-                    tempfile.gettempdir(),
-                    f"{self.tprs_creator.generate_unique_id(sentence, 12)}.wav",
-                )
-                temp_files_to_clean.add(audio_filename)
-                tts_plugin_instance.get_tts(
-                    sentence,
-                    audio_filename,
-                    lang=self.config["languages"]["study_language_code"],
-                    voice=self.config["tts"]["piper"]["voice"],
-                )
-                self.logging.info(
-                    f"[TTS] sentence {sent_idx}/{total_sentences} done ({time.time()-t0:.1f}s)"
-                )
-                media_files.append(audio_filename)
-                media_files.append(pause_filename)
-
-                for qa_idx, (question, answer) in enumerate(tprs_qa_list, 1):
-                    media_files.append(pause_filename)  # Pause before question
-                    question_audio = os.path.join(
-                        tempfile.gettempdir(),
-                        f"{self.tprs_creator.generate_unique_id(question, 12)}.wav",
-                    )
-                    temp_files_to_clean.add(question_audio)
-                    tq = time.time()
-                    tts_plugin_instance.get_tts(
-                        question,
-                        question_audio,
-                        lang=self.config["languages"]["study_language_code"],
-                        voice=self.config["tts"]["piper"]["voice"],
-                    )
-                    self.logging.info(
-                        f"[TTS]   Q {qa_idx}/{len(tprs_qa_list)} (sent {sent_idx}) done ({time.time()-tq:.1f}s)"
-                    )
-                    media_files.append(question_audio)
-
-                    silence_file = os.path.join(
-                        tempfile.gettempdir(),
-                        f"{self.tprs_creator.generate_unique_id('silence_answer', 5)}.wav",
-                    )
-                    temp_files_to_clean.add(silence_file)
-                    # Ensure silence duration is not negative
-                    actual_silence_duration = max(
-                        0, self.config["tts"]["answer_silence_duration"] / repeat_tprs
-                    )
-                    AudioSegment.silent(duration=actual_silence_duration).export(
-                        silence_file, format="wav"
-                    )
-                    media_files.append(silence_file)  # Silence for user to answer
-
-                    answer_audio = os.path.join(
-                        tempfile.gettempdir(),
-                        f"{self.tprs_creator.generate_unique_id(answer, 12)}.wav",
-                    )
-                    temp_files_to_clean.add(answer_audio)
-                    ta = time.time()
-                    tts_plugin_instance.get_tts(
-                        answer,
-                        answer_audio,
-                        lang=self.config["languages"]["study_language_code"],
-                        voice=self.config["tts"]["piper"]["voice"],
-                    )
-                    self.logging.info(
-                        f"[TTS]   A {qa_idx}/{len(tprs_qa_list)} (sent {sent_idx}) done ({time.time()-ta:.1f}s)"
-                    )
-                    media_files.append(answer_audio)
-                    media_files.append(pause_filename)  # Pause after answer
-
-            tts_plugin_instance.stop()
-            self.logging.info(
-                f"[TTS] All {total_tts_calls} calls complete for {self.variant_name} {date_str}"
-            )
-
-            if not media_files:
-                self.logging.warning(
-                    f"No audio segments generated for {self.variant_name} TPRS on {date_str}. Skipping MP3 export."
-                )
-                return
-
-            playlist_media = [
-                AudioSegment.from_wav(wav_file) for wav_file in media_files
-            ]
-            combined = AudioSegment.empty()
-            for segment in playlist_media:
-                for _ in range(repeat_tprs):
-                    combined += segment
-
-            combined.export(tprs_audio_lesson_filepath, format="mp3")
-            self.logging.info(
-                f"Successfully exported {self.variant_name} TPRS audio to {tprs_audio_lesson_filepath}"
-            )
-            # Record the audio path in diary.json so future runs can skip this date
-            self._record_lesson_audio_path(date_str, tprs_audio_lesson_filepath)
-
-        except Exception as e:
-            self.logging.error(
-                f"Error during audio generation for {self.variant_name} TPRS on {date_str}: {e}",
-                exc_info=True,
-            )
-        finally:
-            # Clean up temporary files
-            for f_path in temp_files_to_clean:
-                if os.path.exists(f_path):
-                    try:
-                        os.remove(f_path)
-                    except Exception as e_clean:
-                        self.logging.warning(
-                            f"Could not remove temporary file {f_path}: {e_clean}"
-                        )
-
-    def convert_to_audio(self):
-        """Generates TPRS audio lessons from diary.json Q&A data for this variant.
-
-        Skips any date that already has a non-empty lesson_audio_paths entry for
-        this variant in diary.json — unless overwrite_tprs_audio is True in config.
-        """
-        self.tprs_creator.validate_arguments()
-
-        variant_tprs_dict = self._read_variant_tprs_from_json()
-        if not variant_tprs_dict:
-            self.logging.info(
-                f"No {self.variant_name} TPRS data found in diary.json. Skipping audio generation."
-            )
-            return
-
-        # Load diary.json once to check lesson_audio_paths per date
-        json_path = self.config.get("json_diary_path")
-        diary_db = load_diary_json(json_path) if json_path else None
-
-        force_overwrite = self.config.get("overwrite_tprs_audio", False)
-        # Use the same key convention as audio_timing.py (_VARIANT_KEYS uses "original"
-        # for the Standard variant, not "standard").
-        variant_key = VARIANT_AUDIO_KEY_MAP.get(
-            self.variant_name, self.variant_name.lower()
-        )
-
-        for date_obj, day_qa_dict in variant_tprs_dict.items():
-            date_str = date_obj.strftime("%Y/%m/%d")
-
-            # Skip if audio path already recorded in diary.json for this variant
-            if not force_overwrite and diary_db:
-                day = get_day(diary_db, date_str)
-                if day and day.lesson_audio_paths.get(variant_key):
-                    self.logging.info(
-                        f"Audio already exists for {self.variant_name} on {date_str} — skipping."
-                    )
-                    continue
-
-            day_block_data = {}
-            for sentence_text, qa_numbered_dict in day_qa_dict.items():
-                qa_tuples = [
-                    (qa_numbered_dict[k]["question"], qa_numbered_dict[k]["answer"])
-                    for k in sorted(
-                        qa_numbered_dict.keys(),
-                        key=lambda x: int(x) if x.isdigit() else 0,
-                    )
-                ]
-                day_block_data[sentence_text] = qa_tuples
-
-            self._create_audio_for_day_block(day_block_data, date_str)
-
-        self.logging.info(
-            f"All diary entries converted into {self.variant_name} TPRS audio."
-        )
 
     def _read_variant_tprs_from_json(self):
         """Reads this variant's TPRS Q&A data from diary.json into a structured dictionary.
@@ -2143,25 +1846,21 @@ class TprsCreation(DiaryHandler):
         return new_or_updated_tprs_dict_for_standard
 
 
-def main(config_path=None, skip_audio: bool = False):
+def main(config_path=None):
     """Main function to run the diary and TPRS processing workflow.
 
     Args:
         config_path (str, optional): Path to the configuration file.
                                      Defaults to None, which uses the default user config path.
-        skip_audio (bool): When True, skip convert_to_audio() for all variants.
-                           Use this in the webapp flow where backfill_audio_timings()
-                           handles audio generation and timing in a single pass.
-                           Defaults to False (used by the lingoDiary admin script).
 
     Initializes DiaryHandler, completes translations.
     Then, initializes TprsCreation, checks for missing TPRS sentences,
-    adds missing TPRS content for all versions (standard, enhanced, future, present),
-    and optionally converts all TPRS entries to audio.
+    adds missing TPRS content for all versions (standard, enhanced, future, present).
+    Audio generation is handled separately via backfill_audio_timings() in the webapp.
     """
     diary_instance = DiaryHandler(config_path=config_path)
     _log = diary_instance.logging  # named logger — goes to output.log
-    _log.info("=== Phase 1/3: Diary translations ===")
+    _log.info("=== Phase 1/2: Diary translations ===")
     diary_instance.diary_complete_translations()
     _log.info("=== Diary translations complete ===")
     diary_instance.stop()
@@ -2169,7 +1868,7 @@ def main(config_path=None, skip_audio: bool = False):
     # --- TPRS Processing ---
     tprs_instance = TprsCreation(config_path=config_path)
     _log = tprs_instance.logging  # re-bind after stop() re-opens handlers
-    _log.info("=== Phase 2/3: TPRS Q&A generation ===")
+    _log.info("=== Phase 2/2: TPRS Q&A generation ===")
 
     diary_dict = tprs_instance.json_diary_to_dict()
     if not diary_dict:
@@ -2197,20 +1896,6 @@ def main(config_path=None, skip_audio: bool = False):
         else:
             variant.add_missing_entries(diary_dict, base_tprs_dict)
         _log.info(f"Q&A generation done for {variant.variant_name}.")
-
-        _log.info(f"=== Phase 3/3: Audio generation — {variant.variant_name} ===")
-        if skip_audio:
-            _log.info(
-                f"Skipping convert_to_audio() for {variant.variant_name} "
-                f"(webapp flow — backfill_audio_timings handles audio)."
-            )
-        elif tprs_instance.config.get("create_tprs_audio", True):
-            variant.convert_to_audio()
-        else:
-            _log.info(
-                f"Skipping audio generation for {variant.variant_name} as per configuration."
-            )
-        _log.info(f"Audio done for {variant.variant_name}.")
 
     tprs_instance.stop()
     _log.info("=== All generation complete ===")

--- a/lingodiary/diary.py
+++ b/lingodiary/diary.py
@@ -921,7 +921,12 @@ class TprsVariantHandler:
             f"Generating {self.variant_name} TPRS audio file for {date_str}: {tprs_audio_lesson_filepath}"
         )
 
-        tts_plugin_instance = PiperTTSPlugin()
+        tts_plugin_instance = PiperTTSPlugin(
+            {
+                "lang": self.config["languages"]["study_language_code"],
+                "voice": self.config["tts"]["piper"]["voice"],
+            }
+        )
         tts_plugin_instance.length_scale = self.config["tts"]["piper"][
             "piper_length_scale_tprs"
         ]

--- a/lingodiary/diary.py
+++ b/lingodiary/diary.py
@@ -2138,17 +2138,21 @@ class TprsCreation(DiaryHandler):
         return new_or_updated_tprs_dict_for_standard
 
 
-def main(config_path=None):
+def main(config_path=None, skip_audio: bool = False):
     """Main function to run the diary and TPRS processing workflow.
 
     Args:
         config_path (str, optional): Path to the configuration file.
                                      Defaults to None, which uses the default user config path.
+        skip_audio (bool): When True, skip convert_to_audio() for all variants.
+                           Use this in the webapp flow where backfill_audio_timings()
+                           handles audio generation and timing in a single pass.
+                           Defaults to False (used by the lingoDiary admin script).
 
     Initializes DiaryHandler, completes translations.
     Then, initializes TprsCreation, checks for missing TPRS sentences,
     adds missing TPRS content for all versions (standard, enhanced, future, present),
-    and finally converts all TPRS entries to audio.
+    and optionally converts all TPRS entries to audio.
     """
     diary_instance = DiaryHandler(config_path=config_path)
     _log = diary_instance.logging  # named logger — goes to output.log
@@ -2190,7 +2194,12 @@ def main(config_path=None):
         _log.info(f"Q&A generation done for {variant.variant_name}.")
 
         _log.info(f"=== Phase 3/3: Audio generation — {variant.variant_name} ===")
-        if tprs_instance.config.get("create_tprs_audio", True):
+        if skip_audio:
+            _log.info(
+                f"Skipping convert_to_audio() for {variant.variant_name} "
+                f"(webapp flow — backfill_audio_timings handles audio)."
+            )
+        elif tprs_instance.config.get("create_tprs_audio", True):
             variant.convert_to_audio()
         else:
             _log.info(

--- a/lingodiary/diary_json.py
+++ b/lingodiary/diary_json.py
@@ -81,6 +81,8 @@ class AudioTiming:
 
     @classmethod
     def from_dict(cls, d: dict) -> "AudioTiming":
+        if not isinstance(d, dict):
+            return cls()
         return cls(start_ms=int(d.get("start_ms", 0)), end_ms=int(d.get("end_ms", 0)))
 
 
@@ -115,6 +117,8 @@ class QA:
 
     @classmethod
     def from_dict(cls, d: dict) -> "QA":
+        if not isinstance(d, dict):
+            return cls()
         return cls(
             question=d.get("question", ""),
             answer=d.get("answer", ""),
@@ -153,6 +157,8 @@ class SentenceBlock:
 
     @classmethod
     def from_dict(cls, d: dict) -> "SentenceBlock":
+        if not isinstance(d, dict):
+            return cls()
         return cls(
             sentence=d.get("sentence", ""),
             sentence_input=d.get("sentence_input", ""),
@@ -184,6 +190,8 @@ class ReviewingState:
 
     @classmethod
     def from_dict(cls, d: dict) -> "ReviewingState":
+        if not isinstance(d, dict):
+            return cls()
         return cls(
             status=d.get("status", "new"),
             mastery_score=d.get("mastery_score", 0),
@@ -213,6 +221,8 @@ class VariantSet:
 
     @classmethod
     def from_dict(cls, d: dict) -> "VariantSet":
+        if not isinstance(d, dict):
+            return cls()
         return cls(
             reviewing=ReviewingState.from_dict(d.get("reviewing", {})),
             original=SentenceBlock.from_dict(d.get("original", {})),
@@ -250,6 +260,8 @@ class Sentence:
 
     @classmethod
     def from_dict(cls, d: dict) -> "Sentence":
+        if not isinstance(d, dict):
+            return cls()
         return cls(
             index=d.get("index", 0),
             input_language_sentence=d.get("input_language_sentence", ""),
@@ -285,13 +297,15 @@ class DiaryDay:
 
     @classmethod
     def from_dict(cls, d: dict) -> "DiaryDay":
+        lap = d.get("lesson_audio_paths", {})
+        lmt = d.get("lesson_mp3_timestamps", {})
         return cls(
             date=d.get("date", ""),
             title=d.get("title", ""),
             last_reviewed=d.get("last_reviewed"),
             entries=[Sentence.from_dict(e) for e in d.get("entries", [])],
-            lesson_audio_paths=d.get("lesson_audio_paths", {}),
-            lesson_mp3_timestamps=d.get("lesson_mp3_timestamps", {}),
+            lesson_audio_paths=lap if isinstance(lap, dict) else {},
+            lesson_mp3_timestamps=lmt if isinstance(lmt, dict) else {},
         )
 
 

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -535,52 +535,61 @@ def api_generate_status():
 def api_lessons():
     from flask import g as _g
 
-    items = get_mp3_variants(_g.api_tprs_folder)
     result = []
     diary = None
     try:
-        from lingodiary.diary_json import load_diary_json, compute_stats, get_day
+        from lingodiary.diary_json import load_diary_json
 
         diary = load_diary_json(_g.api_json_diary_path)
     except Exception:
         diary = None
 
-    for base, display, variants in items:
-        lesson = {"base": base, "display": display, "variants": variants}
-        if diary is not None:
-            try:
-                # Match both "…_TPRS_YYYY-MM-DD…" and "TPRS_YYYY-MM-DD…"
-                m = re.search(r"TPRS_(\d{4}-\d{2}-\d{2})", base)
-                if m:
-                    date_dash = m.group(1)
-                    date_slash = date_dash.replace("-", "/")
-                    day = get_day(diary, date_slash)
-                    if day is not None:
-                        lesson["date"] = date_dash
-                        lesson["display"] = (
-                            f"{date_dash}_{day.title}" if day.title else date_dash
-                        )
-                        total = len(day.entries)
-                        mastered = sum(
-                            1
-                            for e in day.entries
-                            if e.lessons.reviewing.status == "mastered"
-                        )
-                        learning = sum(
-                            1
-                            for e in day.entries
-                            if e.lessons.reviewing.status == "learning"
-                        )
-                        new_count = total - mastered - learning
-                        lesson["srs"] = {
-                            "total": total,
-                            "mastered": mastered,
-                            "learning": learning,
-                            "new": new_count,
-                        }
-            except Exception:
-                pass
+    if diary is None:
+        # Fallback: no diary.json — return filesystem-scanned items with no metadata
+        for base, display, variants in get_mp3_variants(_g.api_tprs_folder):
+            result.append({"base": base, "display": display, "variants": variants})
+        return jsonify({"lessons": result})
+
+    for day in diary.diaries:
+        if not day.lesson_audio_paths:
+            continue
+        date_dash = day.date.replace("/", "-")
+        display = f"{date_dash}_{day.title}" if day.title else date_dash
+        # Build variants dict: capitalised key → bare filename (no directory)
+        variants = {
+            k.title(): os.path.basename(v)
+            for k, v in day.lesson_audio_paths.items()
+            if v
+        }
+        if not variants:
+            continue
+        # base = stem of the original MP3 (used by sync manifest matching)
+        original_path = day.lesson_audio_paths.get(
+            "original", next(iter(day.lesson_audio_paths.values()))
+        )
+        base = os.path.splitext(os.path.basename(original_path))[0]
+        lesson = {
+            "base": base,
+            "display": display,
+            "date": date_dash,
+            "variants": variants,
+        }
+        total = len(day.entries)
+        mastered = sum(
+            1 for e in day.entries if e.lessons.reviewing.status == "mastered"
+        )
+        learning = sum(
+            1 for e in day.entries if e.lessons.reviewing.status == "learning"
+        )
+        lesson["srs"] = {
+            "total": total,
+            "mastered": mastered,
+            "learning": learning,
+            "new": total - mastered - learning,
+        }
         result.append(lesson)
+
+    result.sort(key=lambda x: x["date"], reverse=True)
     return jsonify({"lessons": result})
 
 

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import re
+import traceback
 from collections import defaultdict
 from datetime import datetime, timedelta
 from functools import wraps
@@ -320,8 +321,9 @@ def api_generate():
 
             backfill_audio_timings(config_path=config_path, diary_json_path=json_path)
         except Exception as exc:
-            app.logger.warning(f"Audio timing backfill failed: {exc}")
-            _log_to_file(f"WARNING: Audio timing backfill failed: {exc}")
+            tb = traceback.format_exc()
+            app.logger.warning(f"Audio timing backfill failed: {exc}\n{tb}")
+            _log_to_file(f"WARNING: Audio timing backfill failed: {exc}\n{tb}")
         finally:
             _detach_output_log(at_logger, at_handler)
         # 2. Q&A translations — needed for flashcard review.
@@ -414,10 +416,11 @@ def api_backfill_audio_timing():
                 overwrite_existing=overwrite,
             )
         except Exception as exc:
-            app.logger.error(f"Audio timing backfill error: {exc}")
+            tb = traceback.format_exc()
+            app.logger.error(f"Audio timing backfill error: {exc}\n{tb}")
             try:
                 with open(os.path.join(output_folder, "output.log"), "a") as _lf:
-                    _lf.write(f"ERROR: Audio timing backfill failed: {exc}\n")
+                    _lf.write(f"ERROR: Audio timing backfill failed: {exc}\n{tb}\n")
             except Exception:
                 pass
         finally:

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -307,7 +307,7 @@ def api_generate():
             app.logger.warning(f"diary.json backup failed: {exc}")
 
         try:
-            main_diary_tprs(config_path=config_path, skip_audio=True)
+            main_diary_tprs(config_path=config_path)
         except Exception as exc:
             app.logger.error(f"API generate error: {exc}")
             _log_to_file(f"ERROR: Generation failed: {exc}")

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -284,29 +284,30 @@ def api_generate():
         except Exception as exc:
             app.logger.error(f"API generate error: {exc}")
             _log_to_file(f"ERROR: Generation failed: {exc}")
-        # Backfill any missing Q&A translations
-        try:
-            json_path = os.path.join(output_folder, "diary.json")
-            TprsCreation(config_path).backfill_qa_translations(json_path)
-        except Exception as exc:
-            app.logger.warning(f"Q&A translation backfill failed: {exc}")
-            _log_to_file(f"WARNING: Q&A translation backfill failed: {exc}")
-        # Backfill missing variant sentence_input translations
-        try:
-            json_path = os.path.join(output_folder, "diary.json")
-            TprsCreation(config_path).backfill_sentence_inputs(json_path)
-        except Exception as exc:
-            app.logger.warning(f"sentence_input backfill failed: {exc}")
-            _log_to_file(f"WARNING: sentence_input backfill failed: {exc}")
-        # Backfill missing per-sentence audio segments and timing data in diary.json
+        json_path = os.path.join(output_folder, "diary.json")
+        # 1. Audio segments + timing — run first: critical for playback.
+        #    Must happen before the slow translation backfills so a
+        #    container restart cannot starve the new entry of timing data.
         try:
             from lingodiary.audio_timing import backfill_audio_timings
 
-            json_path = os.path.join(output_folder, "diary.json")
             backfill_audio_timings(config_path=config_path, diary_json_path=json_path)
         except Exception as exc:
             app.logger.warning(f"Audio timing backfill failed: {exc}")
             _log_to_file(f"WARNING: Audio timing backfill failed: {exc}")
+        # 2. Q&A translations — needed for flashcard review.
+        try:
+            TprsCreation(config_path).backfill_qa_translations(json_path)
+        except Exception as exc:
+            app.logger.warning(f"Q&A translation backfill failed: {exc}")
+            _log_to_file(f"WARNING: Q&A translation backfill failed: {exc}")
+        # 3. sentence_input translations — low-priority metadata; runs last
+        #    because it iterates ALL historical entries and can be slow.
+        try:
+            TprsCreation(config_path).backfill_sentence_inputs(json_path)
+        except Exception as exc:
+            app.logger.warning(f"sentence_input backfill failed: {exc}")
+            _log_to_file(f"WARNING: sentence_input backfill failed: {exc}")
         # Write a completion marker so the client can stop polling.
         try:
             with open(log_file, "a", encoding="utf-8") as lf:
@@ -399,12 +400,12 @@ def api_backfill_audio_timing():
 @app.route("/api/backfill/all", methods=["POST"])
 @_jwt_required
 def api_backfill_all():
-    """Background job: fill in everything missing — Q&A translations, sentence inputs, audio segments.
+    """Background job: fill in everything missing — audio segments, Q&A translations, sentence inputs.
 
     Runs in sequence:
-      1. backfill_qa_translations    (translate missing Q&A pairs)
-      2. backfill_sentence_inputs    (translate missing variant sentence_input fields)
-      3. backfill_audio_timings      (generate missing segment MP3s + timing data)
+      1. backfill_audio_timings      (generate missing segment MP3s + timing data — critical for playback)
+      2. backfill_qa_translations    (translate missing Q&A pairs)
+      3. backfill_sentence_inputs    (translate missing variant sentence_input fields — slow, runs last)
     """
     from flask import g as _g
 
@@ -414,25 +415,25 @@ def api_backfill_all():
     def _run():
         json_path = os.path.join(output_folder, "diary.json")
 
-        app.logger.info("Backfill all: step 1/3 — Q&A translations")
-        try:
-            TprsCreation(config_path).backfill_qa_translations(json_path)
-        except Exception as exc:
-            app.logger.warning(f"Backfill all: Q&A translation failed: {exc}")
-
-        app.logger.info("Backfill all: step 2/3 — variant sentence_input translations")
-        try:
-            TprsCreation(config_path).backfill_sentence_inputs(json_path)
-        except Exception as exc:
-            app.logger.warning(f"Backfill all: sentence_input backfill failed: {exc}")
-
-        app.logger.info("Backfill all: step 3/3 — audio timing / segments")
+        app.logger.info("Backfill all: step 1/3 — audio timing / segments")
         try:
             from lingodiary.audio_timing import backfill_audio_timings
 
             backfill_audio_timings(config_path=config_path, diary_json_path=json_path)
         except Exception as exc:
             app.logger.warning(f"Backfill all: audio timing failed: {exc}")
+
+        app.logger.info("Backfill all: step 2/3 — Q&A translations")
+        try:
+            TprsCreation(config_path).backfill_qa_translations(json_path)
+        except Exception as exc:
+            app.logger.warning(f"Backfill all: Q&A translation failed: {exc}")
+
+        app.logger.info("Backfill all: step 3/3 — variant sentence_input translations")
+        try:
+            TprsCreation(config_path).backfill_sentence_inputs(json_path)
+        except Exception as exc:
+            app.logger.warning(f"Backfill all: sentence_input backfill failed: {exc}")
 
         app.logger.info("Backfill all: complete")
 

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -280,7 +280,7 @@ def api_generate():
             app.logger.warning(f"diary.json backup failed: {exc}")
 
         try:
-            main_diary_tprs(config_path=config_path)
+            main_diary_tprs(config_path=config_path, skip_audio=True)
         except Exception as exc:
             app.logger.error(f"API generate error: {exc}")
             _log_to_file(f"ERROR: Generation failed: {exc}")

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -48,6 +48,32 @@ JWT_EXPIRY_HOURS = 24 * 7  # 7 days
 _job_queue: queue.Queue = queue.Queue(maxsize=2)
 
 
+class _OutputLogHandler(logging.FileHandler):
+    """FileHandler that flushes after every record (mirrors DiaryHandler's setup)."""
+
+    def emit(self, record):
+        super().emit(record)
+        self.flush()
+
+
+def _attach_output_log(log_file: str) -> tuple:
+    """Add a file handler to the lingodiary.audio_timing logger so that
+    backfill progress is visible in output.log.  Returns (logger, handler)
+    so the caller can remove the handler when done."""
+    handler = _OutputLogHandler(log_file, encoding="utf-8")
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+    at_logger = logging.getLogger("lingodiary.audio_timing")
+    at_logger.setLevel(logging.DEBUG)
+    at_logger.addHandler(handler)
+    return at_logger, handler
+
+
+def _detach_output_log(at_logger, handler) -> None:
+    at_logger.removeHandler(handler)
+    handler.close()
+
+
 def _start_job_worker():
     """Single background worker that drains the job queue sequentially."""
     while True:
@@ -288,6 +314,7 @@ def api_generate():
         # 1. Audio segments + timing — run first: critical for playback.
         #    Must happen before the slow translation backfills so a
         #    container restart cannot starve the new entry of timing data.
+        at_logger, at_handler = _attach_output_log(log_file)
         try:
             from lingodiary.audio_timing import backfill_audio_timings
 
@@ -295,6 +322,8 @@ def api_generate():
         except Exception as exc:
             app.logger.warning(f"Audio timing backfill failed: {exc}")
             _log_to_file(f"WARNING: Audio timing backfill failed: {exc}")
+        finally:
+            _detach_output_log(at_logger, at_handler)
         # 2. Q&A translations — needed for flashcard review.
         try:
             TprsCreation(config_path).backfill_qa_translations(json_path)
@@ -373,6 +402,8 @@ def api_backfill_audio_timing():
     overwrite = bool(body.get("overwrite", False))
 
     def _run():
+        log_file = os.path.join(output_folder, "output.log")
+        at_logger, at_handler = _attach_output_log(log_file)
         try:
             from lingodiary.audio_timing import backfill_audio_timings
 
@@ -384,6 +415,13 @@ def api_backfill_audio_timing():
             )
         except Exception as exc:
             app.logger.error(f"Audio timing backfill error: {exc}")
+            try:
+                with open(os.path.join(output_folder, "output.log"), "a") as _lf:
+                    _lf.write(f"ERROR: Audio timing backfill failed: {exc}\n")
+            except Exception:
+                pass
+        finally:
+            _detach_output_log(at_logger, at_handler)
 
     try:
         _job_queue.put_nowait(_run)
@@ -413,29 +451,40 @@ def api_backfill_all():
     output_folder = _g.api_output_folder
 
     def _run():
-        json_path = os.path.join(output_folder, "diary.json")
-
-        app.logger.info("Backfill all: step 1/3 — audio timing / segments")
+        log_file = os.path.join(output_folder, "output.log")
+        at_logger, at_handler = _attach_output_log(log_file)
         try:
-            from lingodiary.audio_timing import backfill_audio_timings
+            json_path = os.path.join(output_folder, "diary.json")
 
-            backfill_audio_timings(config_path=config_path, diary_json_path=json_path)
-        except Exception as exc:
-            app.logger.warning(f"Backfill all: audio timing failed: {exc}")
+            app.logger.info("Backfill all: step 1/3 — audio timing / segments")
+            try:
+                from lingodiary.audio_timing import backfill_audio_timings
 
-        app.logger.info("Backfill all: step 2/3 — Q&A translations")
-        try:
-            TprsCreation(config_path).backfill_qa_translations(json_path)
-        except Exception as exc:
-            app.logger.warning(f"Backfill all: Q&A translation failed: {exc}")
+                backfill_audio_timings(
+                    config_path=config_path, diary_json_path=json_path
+                )
+            except Exception as exc:
+                app.logger.warning(f"Backfill all: audio timing failed: {exc}")
 
-        app.logger.info("Backfill all: step 3/3 — variant sentence_input translations")
-        try:
-            TprsCreation(config_path).backfill_sentence_inputs(json_path)
-        except Exception as exc:
-            app.logger.warning(f"Backfill all: sentence_input backfill failed: {exc}")
+            app.logger.info("Backfill all: step 2/3 — Q&A translations")
+            try:
+                TprsCreation(config_path).backfill_qa_translations(json_path)
+            except Exception as exc:
+                app.logger.warning(f"Backfill all: Q&A translation failed: {exc}")
 
-        app.logger.info("Backfill all: complete")
+            app.logger.info(
+                "Backfill all: step 3/3 — variant sentence_input translations"
+            )
+            try:
+                TprsCreation(config_path).backfill_sentence_inputs(json_path)
+            except Exception as exc:
+                app.logger.warning(
+                    f"Backfill all: sentence_input backfill failed: {exc}"
+                )
+
+            app.logger.info("Backfill all: complete")
+        finally:
+            _detach_output_log(at_logger, at_handler)
 
     try:
         _job_queue.put_nowait(_run)

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -549,12 +549,17 @@ def api_lessons():
         lesson = {"base": base, "display": display, "variants": variants}
         if diary is not None:
             try:
-                m = re.search(r"_TPRS_(\d{4}-\d{2}-\d{2})", base)
+                # Match both "…_TPRS_YYYY-MM-DD…" and "TPRS_YYYY-MM-DD…"
+                m = re.search(r"TPRS_(\d{4}-\d{2}-\d{2})", base)
                 if m:
                     date_dash = m.group(1)
                     date_slash = date_dash.replace("-", "/")
                     day = get_day(diary, date_slash)
                     if day is not None:
+                        lesson["date"] = date_dash
+                        lesson["display"] = (
+                            f"{date_dash}_{day.title}" if day.title else date_dash
+                        )
                         total = len(day.entries)
                         mastered = sum(
                             1

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -607,6 +607,7 @@ def api_sync_manifest():
                 fname.startswith(".")
                 or fname.endswith(".zip")
                 or fname.endswith(".log")
+                or fname == "diary.json"
             ):
                 continue
             full = os.path.join(root, fname)
@@ -641,10 +642,7 @@ def api_sync_file(rel_path):
 @app.route("/api/sync/manifest/<path:base>", methods=["GET"])
 @_jwt_required
 def api_sync_lesson_manifest(base):
-    """Return manifest filtered to files belonging to a single lesson (by base name).
-
-    Always includes diary.json so the app can read lesson text offline.
-    """
+    """Return manifest filtered to files belonging to a single lesson (by base name)."""
     from flask import g as _g
 
     output_folder = _g.api_output_folder
@@ -659,8 +657,7 @@ def api_sync_lesson_manifest(base):
                 continue
             full = os.path.join(root, fname)
             rel = os.path.relpath(full, output_folder)
-            # Always include diary.json so lesson text is available offline
-            if base not in rel and rel != "diary.json":
+            if base not in rel:
                 continue
             stat = os.stat(full)
             manifest.append(
@@ -688,6 +685,26 @@ def api_get_diary_json():
         return jsonify(diary.to_dict())
     except Exception as exc:
         return jsonify({"error": str(exc)}), 500
+
+
+@app.route("/api/diary/day/<date>", methods=["GET"])
+@_jwt_required
+def api_diary_day(date):
+    """Return the complete Day object for a given date (all variants, all entries, title, etc.)."""
+    from flask import g as _g
+    from lingodiary.diary_json import load_diary_json, get_day
+
+    date_slash = date.replace("-", "/")
+    try:
+        diary = load_diary_json(_g.api_json_diary_path)
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    day = get_day(diary, date_slash)
+    if day is None:
+        return jsonify({"error": "Date not found"}), 404
+
+    return jsonify(day.to_dict())
 
 
 @app.route("/api/diary/json", methods=["POST"])

--- a/tests/test_audio_timing.py
+++ b/tests/test_audio_timing.py
@@ -15,7 +15,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from lingodiary.audio_timing import (
-    _mp3_stale,
     _recompute_timings_from_segments,
     _segments_complete,
 )
@@ -61,68 +60,6 @@ def _make_day(entries=None, mp3_ts=None) -> DiaryDay:
     if mp3_ts:
         day.lesson_mp3_timestamps["original"] = mp3_ts
     return day
-
-
-# ── _mp3_stale ─────────────────────────────────────────────────────────────────
-
-
-class TestMp3Stale:
-    def test_no_mp3_timestamp_returns_false(self):
-        """No timestamp → can't determine staleness → return False."""
-        day = _make_day()
-        assert _mp3_stale(day, "original") is False
-
-    def test_malformed_mp3_timestamp_returns_true(self):
-        """Malformed MP3 timestamp → treat as stale → return True."""
-        day = _make_day(mp3_ts="not-a-date")
-        assert _mp3_stale(day, "original") is True
-
-    def test_fresh_segments_returns_false(self):
-        """All segment timestamps older than MP3 → not stale."""
-        day = _make_day(mp3_ts="2026-01-02T00:00:00+00:00")
-        # Sentence and QA generated_at are 2026-01-01, MP3 is 2026-01-02
-        assert _mp3_stale(day, "original") is False
-
-    def test_newer_sentence_segment_returns_true(self):
-        """Sentence segment newer than MP3 → stale."""
-        entry = _make_sentence()
-        entry.lessons.original.sentence_audio_generated_at = "2026-01-03T00:00:00+00:00"
-        day = _make_day(entries=[entry], mp3_ts="2026-01-02T00:00:00+00:00")
-        assert _mp3_stale(day, "original") is True
-
-    def test_newer_qa_segment_returns_true(self):
-        """QA segment newer than MP3 → stale."""
-        entry = _make_sentence()
-        entry.lessons.original.qa[0].generated_at = "2026-01-03T00:00:00+00:00"
-        day = _make_day(entries=[entry], mp3_ts="2026-01-02T00:00:00+00:00")
-        assert _mp3_stale(day, "original") is True
-
-    def test_missing_sentence_generated_at_returns_true(self):
-        """No sentence_audio_generated_at → treat as stale."""
-        entry = _make_sentence()
-        entry.lessons.original.sentence_audio_generated_at = None
-        day = _make_day(entries=[entry], mp3_ts="2026-01-02T00:00:00+00:00")
-        assert _mp3_stale(day, "original") is True
-
-    def test_missing_qa_generated_at_returns_true(self):
-        """No qa.generated_at → treat as stale."""
-        entry = _make_sentence()
-        entry.lessons.original.qa[0].generated_at = None
-        day = _make_day(entries=[entry], mp3_ts="2026-01-02T00:00:00+00:00")
-        assert _mp3_stale(day, "original") is True
-
-    def test_malformed_sentence_generated_at_returns_true(self):
-        """Malformed sentence_audio_generated_at → treat as stale."""
-        entry = _make_sentence()
-        entry.lessons.original.sentence_audio_generated_at = "garbage"
-        day = _make_day(entries=[entry], mp3_ts="2026-01-02T00:00:00+00:00")
-        assert _mp3_stale(day, "original") is True
-
-    def test_wrong_variant_not_stale(self):
-        """Checking a variant that has no MP3 timestamp → False (no timestamp)."""
-        day = _make_day(mp3_ts="2026-01-02T00:00:00+00:00")
-        # 'enhanced' has no mp3 timestamp — should return False
-        assert _mp3_stale(day, "enhanced") is False
 
 
 # ── _segments_complete ─────────────────────────────────────────────────────────


### PR DESCRIPTION
- **fix: run audio timing backfill before sentence_input backfill on generate**
- **fix: skip convert_to_audio() in webapp flow; delegate to backfill_audio_timings**
- **fix: route audio_timing logger to output.log during all webapp backfill runs**
- **fix: guard from_dict against non-dict values; log full traceback on backfill errors**
- **fix: pass explicit lang/config to PiperTTSPlugin to avoid OVOS config lookup**
- **fix: pass config dict as first positional arg to PiperTTSPlugin**
- **refactor: extract _process_day_audio, remove CLI audio path, drop _mp3_stale**
- **fix: use diary.json date+title for lesson display; fix TPRS_ regex**
- **fix: build lesson list from diary.json, not filesystem scanning**
- **fix: navigate to player via go_router so bottom nav back works**
- **feat(flutter): add l10n for all hardcoded strings across all screens**
- **feat: replace diary.json sync with per-day SQLite cache**
