### PR TITLE
feat: add Translation Attempt feature with offline queue

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,13 @@ SM-2 spaced-repetition metadata for one **Sentence**: status (`new` / `learning`
 `mastered`), mastery score (0–5), interval, and next-review date.  Shared across
 all Lesson Variants of the same Sentence.  `ReviewingState` in code.
 
+### Translation Attempt
+The learner's own rendering of a **Sentence** in the **Output Language**, written
+before the AI-generated translation is revealed.  Stored per-Sentence in
+`user_trial_translation`.  Not meant to be correct — its value is in the act of
+trying.
+_Avoid_: trial sentence, trial translation, draft translation
+
 ### TPRS
 Total Physical Response Storytelling — the language-teaching method that motivates
 the Lesson Variant / Q&A structure.  Also used as the top-level folder name for

--- a/android_app/lib/l10n/app_localizations.dart
+++ b/android_app/lib/l10n/app_localizations.dart
@@ -170,6 +170,13 @@ class AppLocalizations {
   String scoreSavedLocallyError(String error) => _t('scoreSavedLocallyError').replaceAll('{error}', error);
   String get translationAttemptHintWithEnter => _t('translationAttemptHintWithEnter');
   String get translationAttemptLabel => _t('translationAttemptLabel');
+  String get translateNowButton => _t('translateNowButton');
+  String get translationAttemptTitle => _t('translationAttemptTitle');
+  String get saveAttemptsButton => _t('saveAttemptsButton');
+  String get translationAttemptHint => _t('translationAttemptHint');
+  String get translationAttemptSaved => _t('translationAttemptSaved');
+  String get translationAttemptSavedLocally => _t('translationAttemptSavedLocally');
+  String get translationAttemptSkip => _t('translationAttemptSkip');
   String get fontSizeSmall => _t('fontSizeSmall');
   String get fontSizeNormal => _t('fontSizeNormal');
   String get fontSizeLarge => _t('fontSizeLarge');
@@ -357,6 +364,13 @@ class AppLocalizations {
       'scoreSavedLocallyError': 'Score saved locally — sync error: {error}',
       'translationAttemptHintWithEnter': 'Your translation attempt (press Enter to reveal)',
       'translationAttemptLabel': 'Your translation attempt',
+      'translateNowButton': 'Translate Now',
+      'translationAttemptTitle': 'Translation Attempts',
+      'saveAttemptsButton': 'Save Attempts',
+      'translationAttemptHint': 'Your translation attempt…',
+      'translationAttemptSaved': 'Translation attempts saved!',
+      'translationAttemptSavedLocally': 'Saved locally — will sync when online.',
+      'translationAttemptSkip': 'Skip',
       'fontSizeSmall': 'Small',
       'fontSizeNormal': 'Normal',
       'fontSizeLarge': 'Large',
@@ -538,6 +552,13 @@ class AppLocalizations {
       'scoreSavedLocallyError': 'Score enregistré localement — erreur de sync : {error}',
       'translationAttemptHintWithEnter': 'Votre tentative de traduction (appuyez sur Entrée pour révéler)',
       'translationAttemptLabel': 'Votre tentative de traduction',
+      'translateNowButton': 'Traduire maintenant',
+      'translationAttemptTitle': 'Tentatives de traduction',
+      'saveAttemptsButton': 'Enregistrer les tentatives',
+      'translationAttemptHint': 'Votre tentative de traduction…',
+      'translationAttemptSaved': 'Tentatives de traduction enregistrées !',
+      'translationAttemptSavedLocally': 'Enregistré localement — sera synchronisé en ligne.',
+      'translationAttemptSkip': 'Ignorer',
       'fontSizeSmall': 'Petit',
       'fontSizeNormal': 'Normal',
       'fontSizeLarge': 'Grand',
@@ -718,6 +739,13 @@ class AppLocalizations {
       'scoreSavedLocallyError': 'Puntuación guardada localmente — error de sincronización: {error}',
       'translationAttemptHintWithEnter': 'Tu intento de traducción (presiona Enter para revelar)',
       'translationAttemptLabel': 'Tu intento de traducción',
+      'translateNowButton': 'Traducir ahora',
+      'translationAttemptTitle': 'Intentos de traducción',
+      'saveAttemptsButton': 'Guardar intentos',
+      'translationAttemptHint': 'Tu intento de traducción…',
+      'translationAttemptSaved': '¡Intentos de traducción guardados!',
+      'translationAttemptSavedLocally': 'Guardado localmente — se sincronizará cuando esté en línea.',
+      'translationAttemptSkip': 'Omitir',
       'fontSizeSmall': 'Pequeño',
       'fontSizeNormal': 'Normal',
       'fontSizeLarge': 'Grande',

--- a/android_app/lib/screens/diary_screen.dart
+++ b/android_app/lib/screens/diary_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../l10n/app_localizations.dart';
 import '../services/api_service.dart';
 import '../services/local_db_service.dart';
+import 'translation_attempt_screen.dart';
 
 class DiaryScreen extends StatefulWidget {
   const DiaryScreen({super.key});
@@ -26,6 +27,8 @@ class _DiaryScreenState extends State<DiaryScreen> {
   int _logOffset = 0;
   String? _error;
   String? _successMessage;
+  List<String>? _savedSentences;
+  String? _savedDate;
 
   // ── date picker ──────────────────────────────────────────────────────────────
 
@@ -105,10 +108,13 @@ class _DiaryScreenState extends State<DiaryScreen> {
       final entryText = _sentences.map((s) => '- $s').join('\n');
       await LocalDbService.saveDiaryContent('[$dateStr]\n$entryText');
       final count = _sentences.length;
+      final savedSentencesCopy = List<String>.from(_sentences);
       setState(() {
         _successMessage = l10n.diaryEntrySaved(dateStr, count);
         _sentences.clear();
         _editingIndex = -1;
+        _savedSentences = savedSentencesCopy;
+        _savedDate = dateStr;
       });
     } catch (e) {
       // Save locally even when offline — will be retried on next sync.
@@ -296,6 +302,26 @@ class _DiaryScreenState extends State<DiaryScreen> {
               ),
               child: Text(_successMessage!,
                   style: TextStyle(color: Colors.green.shade800)),
+            ),
+          if (_savedSentences != null && _savedSentences!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: FilledButton.icon(
+                onPressed: () {
+                  Navigator.of(context).push(MaterialPageRoute(
+                    builder: (_) => TranslationAttemptScreen(
+                      date: _savedDate!,
+                      sentences: _savedSentences!,
+                    ),
+                  ));
+                },
+                icon: const Icon(Icons.translate),
+                label: Text(l10n.translateNowButton),
+                style: FilledButton.styleFrom(
+                  backgroundColor: Colors.teal,
+                  foregroundColor: Colors.white,
+                ),
+              ),
             ),
           if (_error != null)
             Container(

--- a/android_app/lib/screens/translation_attempt_screen.dart
+++ b/android_app/lib/screens/translation_attempt_screen.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import '../l10n/app_localizations.dart';
+import '../services/local_db_service.dart';
+import '../services/sync_manager.dart';
+
+class TranslationAttemptScreen extends StatefulWidget {
+  final String date;
+  final List<String> sentences;
+
+  const TranslationAttemptScreen({
+    super.key,
+    required this.date,
+    required this.sentences,
+  });
+
+  @override
+  State<TranslationAttemptScreen> createState() => _TranslationAttemptScreenState();
+}
+
+class _TranslationAttemptScreenState extends State<TranslationAttemptScreen> {
+  late final List<TextEditingController> _controllers;
+  bool _saving = false;
+  String? _error;
+  String? _successMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = widget.sentences.map((_) => TextEditingController()).toList();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _controllers) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> _saveAttempts() async {
+    final l10n = AppLocalizations.of(context);
+    final trials = _controllers.map((c) => c.text.trim()).toList();
+
+    setState(() {
+      _saving = true;
+      _error = null;
+      _successMessage = null;
+    });
+
+    // Save to local queue first (offline-safe)
+    await LocalDbService.savePendingTrials(widget.date, trials);
+
+    // If online, trigger a flush (non-blocking)
+    if (SyncManager.instance.isOnline) {
+      SyncManager.instance.flushPending(); // fire and forget
+    }
+
+    if (mounted) {
+      setState(() {
+        _successMessage = SyncManager.instance.isOnline
+            ? l10n.translationAttemptSaved
+            : l10n.translationAttemptSavedLocally;
+        _saving = false;
+      });
+      await Future.delayed(const Duration(seconds: 1));
+      if (mounted) Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.translationAttemptTitle),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.of(context).pop(),
+          tooltip: l10n.translationAttemptSkip,
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: widget.sentences.length,
+              itemBuilder: (ctx, i) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '${i + 1}. ${widget.sentences[i]}',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(fontWeight: FontWeight.w500),
+                      ),
+                      const SizedBox(height: 6),
+                      TextField(
+                        controller: _controllers[i],
+                        decoration: InputDecoration(
+                          hintText: l10n.translationAttemptHint,
+                          border: const OutlineInputBorder(),
+                          isDense: true,
+                          contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 10),
+                        ),
+                        textInputAction: i < widget.sentences.length - 1
+                            ? TextInputAction.next
+                            : TextInputAction.done,
+                        maxLines: null,
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+          if (_successMessage != null)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(10),
+              margin: const EdgeInsets.symmetric(horizontal: 16),
+              decoration: BoxDecoration(
+                color: Colors.green.shade50,
+                border: Border.all(color: Colors.green.shade200),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(_successMessage!,
+                  style: TextStyle(color: Colors.green.shade800)),
+            ),
+          if (_error != null)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(10),
+              margin: const EdgeInsets.symmetric(horizontal: 16),
+              decoration: BoxDecoration(
+                color: Colors.orange.shade50,
+                border: Border.all(color: Colors.orange.shade200),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(_error!,
+                  style: TextStyle(color: Colors.orange.shade900)),
+            ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: _saving ? null : () => Navigator.of(context).pop(),
+                    child: Text(l10n.translationAttemptSkip),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton.icon(
+                    onPressed: _saving ? null : _saveAttempts,
+                    icon: _saving
+                        ? const SizedBox(
+                            height: 16,
+                            width: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: Colors.white))
+                        : const Icon(Icons.save),
+                    label: Text(l10n.saveAttemptsButton),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/android_app/lib/services/api_service.dart
+++ b/android_app/lib/services/api_service.dart
@@ -351,4 +351,20 @@ class ApiService {
     final data = jsonDecode(resp.body) as Map<String, dynamic>;
     return List<Map<String, dynamic>>.from(data['lessons'] as List);
   }
+
+  static Future<void> saveTrials(String date, List<String> trials) async {
+    final base = await _baseUrl();
+    final headers = await _authHeaders();
+    final resp = await http
+        .post(
+          Uri.parse('$base/api/diary/$date/trials'),
+          headers: headers,
+          body: jsonEncode({'trials': trials}),
+        )
+        .timeout(_timeout);
+    if (resp.statusCode != 200) {
+      final body = jsonDecode(resp.body) as Map<String, dynamic>;
+      throw ApiException(resp.statusCode, body['error'] ?? 'Failed to save trials');
+    }
+  }
 }

--- a/android_app/lib/services/db_mobile.dart
+++ b/android_app/lib/services/db_mobile.dart
@@ -14,11 +14,12 @@ class LocalDbService {
     final path = join(await getDatabasesPath(), 'lingodiary.db');
     return openDatabase(
       path,
-      version: 3,
+      version: 4,
       onCreate: (db, version) async {
         await _createV1Tables(db);
         await _createV2Tables(db);
         await _createV3Tables(db);
+        await _createV4Tables(db);
       },
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -26,6 +27,9 @@ class LocalDbService {
         }
         if (oldVersion < 3) {
           await _createV3Tables(db);
+        }
+        if (oldVersion < 4) {
+          await _createV4Tables(db);
         }
       },
     );
@@ -83,6 +87,17 @@ class LocalDbService {
         date TEXT PRIMARY KEY,
         day_json TEXT NOT NULL,
         fetched_at TEXT NOT NULL
+      )
+    ''');
+  }
+
+  static Future<void> _createV4Tables(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS pending_trials (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        date TEXT NOT NULL,
+        trials_json TEXT NOT NULL,
+        synced INTEGER NOT NULL DEFAULT 0
       )
     ''');
   }
@@ -342,6 +357,7 @@ class LocalDbService {
     await database.delete('srs_scores');
     await database.delete('lesson_last_reviewed');
     await database.delete('day_cache');
+    await database.delete('pending_trials');
   }
 
   // ---- Lesson last_reviewed tracking ----
@@ -377,5 +393,31 @@ class LocalDbService {
       orderBy: 'last_reviewed DESC',
       limit: limit,
     );
+  }
+
+  // ---- Translation attempts ----
+
+  static Future<void> savePendingTrials(String date, List<String> trials) async {
+    final database = await db;
+    await database.insert('pending_trials', {
+      'date': date,
+      'trials_json': jsonEncode(trials),
+      'synced': 0,
+    });
+  }
+
+  static Future<List<Map<String, dynamic>>> getUnsyncedTrials() async {
+    final database = await db;
+    final rows = await database.query('pending_trials', where: 'synced = 0', orderBy: 'id ASC');
+    return rows.map((r) => {
+      'id': r['id'] as int,
+      'date': r['date'] as String,
+      'trials': (jsonDecode(r['trials_json'] as String) as List).cast<String>(),
+    }).toList();
+  }
+
+  static Future<void> markTrialSynced(int id) async {
+    final database = await db;
+    await database.update('pending_trials', {'synced': 1}, where: 'id = ?', whereArgs: [id]);
   }
 }

--- a/android_app/lib/services/db_stub.dart
+++ b/android_app/lib/services/db_stub.dart
@@ -111,4 +111,9 @@ class LocalDbService {
   static Future<Map<String, dynamic>?> getDayCache(String date) async => null;
 
   static Future<List<String>> getAllCachedDates() async => [];
+
+  // ---- Translation attempts (no-op on stub) ----
+  static Future<void> savePendingTrials(String date, List<String> trials) async {}
+  static Future<List<Map<String, dynamic>>> getUnsyncedTrials() async => [];
+  static Future<void> markTrialSynced(int id) async {}
 }

--- a/android_app/lib/services/db_web.dart
+++ b/android_app/lib/services/db_web.dart
@@ -139,4 +139,9 @@ class LocalDbService {
   static Future<Map<String, dynamic>?> getDayCache(String date) async => null;
 
   static Future<List<String>> getAllCachedDates() async => [];
+
+  // ---- Translation attempts (no-op on web) ----
+  static Future<void> savePendingTrials(String date, List<String> trials) async {}
+  static Future<List<Map<String, dynamic>>> getUnsyncedTrials() async => [];
+  static Future<void> markTrialSynced(int id) async {}
 }

--- a/android_app/lib/services/sync_manager.dart
+++ b/android_app/lib/services/sync_manager.dart
@@ -82,7 +82,7 @@ class SyncManager extends ChangeNotifier {
     _cancelled = true;
   }
 
-  /// Flushes pending scores, diary entries, and lesson reviews to the server.
+  /// Flushes pending scores, diary entries, lesson reviews, and translation trials to the server.
   /// Safe to call concurrently — a second call is ignored while one is running.
   Future<void> flushPending() async {
     if (_flushing) return;
@@ -91,6 +91,7 @@ class SyncManager extends ChangeNotifier {
       await _syncPendingLessonReviews();
       await _syncPendingDiaryEntries();
       await _syncPendingScores();
+      await _syncPendingTrials();
     } finally {
       _flushing = false;
     }
@@ -266,6 +267,26 @@ class SyncManager extends ChangeNotifier {
           break; // Network unreachable — retry on next sync.
         }
         debugPrint('SyncManager: diary entry sync failed for row $id: $e');
+      }
+    }
+  }
+
+  /// Flush pending translation attempts to the server.
+  Future<void> _syncPendingTrials() async {
+    final pending = await LocalDbService.getUnsyncedTrials();
+    for (final row in pending) {
+      if (_cancelled) break;
+      final id = row['id'] as int;
+      final date = row['date'] as String;
+      final trials = row['trials'] as List<String>;
+      try {
+        await ApiService.saveTrials(date, trials);
+        await LocalDbService.markTrialSynced(id);
+      } catch (e) {
+        if (e.toString().contains('SocketException') || e.toString().contains('Connection refused')) {
+          break;
+        }
+        debugPrint('SyncManager: trial sync failed for row $id: $e');
       }
     }
   }

--- a/lingodiary/webapp.py
+++ b/lingodiary/webapp.py
@@ -970,6 +970,48 @@ def api_add_diary_entry():
     )
 
 
+@app.route("/api/diary/<date>/trials", methods=["POST"])
+@_jwt_required
+def api_save_trials(date):
+    """Save user_trial_translation for each sentence of a day.
+    Body: {"trials": ["attempt1", "attempt2", ...]} ordered by sentence index (1-based).
+    """
+    from flask import g as _g
+
+    data = request.get_json(silent=True) or {}
+    trials = data.get("trials", [])
+    if not trials:
+        return jsonify({"error": "trials list is required"}), 400
+
+    try:
+        datetime.strptime(date, "%Y-%m-%d")
+    except ValueError:
+        return jsonify({"error": "Invalid date format, expected YYYY-MM-DD"}), 400
+
+    try:
+        from lingodiary.diary_json import load_diary_json, save_diary_json, get_day
+
+        json_path = _g.api_json_diary_path
+        if not json_path:
+            return jsonify({"error": "json_diary_path not configured"}), 500
+
+        date_slash = date.replace("-", "/")
+        diary_json = load_diary_json(json_path)
+        day = get_day(diary_json, date_slash)
+        if day is None:
+            return jsonify({"error": f"No diary entry for {date}"}), 404
+
+        for i, trial in enumerate(trials):
+            if i < len(day.entries):
+                day.entries[i].user_trial_translation = trial
+        save_diary_json(diary_json, json_path)
+    except Exception as exc:
+        app.logger.error(f"api_save_trials error: {exc}")
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify({"success": True, "date": date, "trials_saved": len(trials)})
+
+
 @app.route("/api/config", methods=["GET"])
 @_jwt_required
 def api_get_config():


### PR DESCRIPTION
- POST /api/diary/<date>/trials endpoint saves user_trial_translation per sentence
- pending_trials SQLite table (DB v4) queues attempts offline
- SyncManager.flushPending() flushes pending trials on reconnect
- TranslationAttemptScreen: scrollable sentence list with one text field each
- DiaryScreen: "Translate Now" button appears after successful sentence save
- l10n: translateNowButton, translationAttemptTitle, saveAttemptsButton, etc. (EN/FR/ES)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
