### PR TITLE
Fix: Generate launcher icons in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,10 @@ jobs:
         working-directory: android_app
         run: flutter pub get
 
+      - name: Generate launcher icons
+        working-directory: android_app
+        run: flutter pub run flutter_launcher_icons
+
       - name: Analyze Flutter code
         working-directory: android_app
         run: flutter analyze --no-fatal-infos
@@ -296,6 +300,10 @@ jobs:
       - name: Install Flutter dependencies
         working-directory: android_app
         run: flutter pub get
+
+      - name: Generate launcher icons
+        working-directory: android_app
+        run: flutter pub run flutter_launcher_icons
 
       - name: Build Flutter web
         working-directory: android_app


### PR DESCRIPTION
Apply the same launcher icon generation fix to release.yml workflows. Both build-apk and build-flutter-web jobs now run flutter_launcher_icons after flutter pub get to ensure launcher icons are present for the build.

This prevents AAPT errors about missing mipmap/launcher_icon resources in the release APK build.